### PR TITLE
Add phase skills and update commands for 0.1.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neuroflow",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "End-to-end research workflow plugin for neuroscience teams — from hypothesis to publication. Supports EEG, iEEG, fMRI, eye tracking, ECG, and other neuroscience modalities.",
   "author": {
     "name": "Stanislav Jiricek"

--- a/.neuroflow/sentinel-dev.md
+++ b/.neuroflow/sentinel-dev.md
@@ -1,14 +1,28 @@
-# sentinel-dev
+Last run: 2026-03-10
 
-Last run: 2026-03-09
+## Issues found
 
-## All clear
+- **Naming overlap — agent `sentinel` and command `sentinel` share the same name.** `agents/sentinel.md` (`name: sentinel`) and `commands/sentinel.md` (`name: sentinel`) are identical. The agent is invoked by the command, so the overlap is structural, but it can cause confusion when referencing them in documentation or skill files. The previous run flagged this as intentional by design; noting here for completeness.
 
-All checks passed. No issues found.
+## Checks passed
 
 ### Check 1 — Folder name vs frontmatter name: PASS
-### Check 2 — README tables: PASS (15 commands, 4 skills, 3 agents)
-### Check 3 — Version sync (0.1.1): PASS
-### Check 4 — Dead references in command files: PASS (bids-structure ref removed from data.md)
-### Check 5 — Naming overlaps: PASS (sentinel command/agent overlap is intentional by design)
-### Check 6 — Command frontmatter completeness: PASS (all 15 commands)
+All 16 `skills/*/SKILL.md` `name:` fields match their folder names exactly. All 3 agent files (`scholar`, `sentinel`, `sentinel-dev`) match their filenames. All 15 command files match their filenames.
+
+### Check 2 — README tables: PASS
+All 15 command files have a matching row in the Commands table. All 16 skill folders have a matching row in the Skills table. All table links resolve to existing files.
+
+### Check 3 — Version sync: PASS
+`plugin.json` version `0.1.2` matches the `## What's new in 0.1.2` heading in `README.md`.
+
+### Check 4 — Dead references inside SKILL.md files: PASS
+All `neuroflow:` references found across SKILL.md files (`neuroflow:neuroflow-core`, `neuroflow:review-neuro`) point to existing skill folders.
+
+### Check 5 — Naming overlaps: NOTE (intentional)
+`sentinel` is both a command name (`commands/sentinel.md`) and an agent name (`agents/sentinel.md`). Flagged previously as intentional by design. No other overlaps found between skill names, command names, and agent names.
+
+### Check 6 — Command frontmatter completeness: PASS
+All 15 command files contain the five required frontmatter fields: `name`, `description`, `phase`, `reads`, `writes`.
+
+### Check 7 — plugin.json consistency: PASS
+`plugin.json` contains: `name`, `version`, `description`, `author`, `homepage`, `repository`, `license`, `keywords`, `mcpServers` (pubmed, biorxiv, miro, context7). All referenced MCP servers use standard `npx -y` invocation patterns. No issues found.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@
 
 ---
 
+## What's new in 0.1.2
+
+- 12 phase skills — [`neuroflow:phase-ideation`](skills/phase-ideation/SKILL.md) through [`neuroflow:phase-write-report`](skills/phase-write-report/SKILL.md) — each loaded automatically by its corresponding command to orient agent approach, relevant skills, and workflow hints
+
 ## What's new in 0.1.1
 
 - Full research pipeline — 15 commands from [`/start`](commands/start.md) through [`/paper-review`](commands/paper-review.md), each writing to `.neuroflow/` project memory
@@ -91,6 +95,18 @@ Skills are invoked by Claude automatically when relevant, or triggered explicitl
 | [`neuroflow:review-neuro`](skills/review-neuro/SKILL.md) | Rigorous pre-submission peer review of a neuroscience manuscript |
 | [`neuroflow:neuroflow-develop`](skills/neuroflow-develop/SKILL.md) | Guide for developing and maintaining the neuroflow plugin |
 | [`neuroflow:skill-creator`](skills/skill-creator/SKILL.md) | Guide for creating new neuroflow skills |
+| [`neuroflow:phase-ideation`](skills/phase-ideation/SKILL.md) | Phase guidance for /ideation — approach, relevant skills, workflow hints |
+| [`neuroflow:phase-grant-proposal`](skills/phase-grant-proposal/SKILL.md) | Phase guidance for /grant-proposal |
+| [`neuroflow:phase-experiment`](skills/phase-experiment/SKILL.md) | Phase guidance for /experiment |
+| [`neuroflow:phase-tool-build`](skills/phase-tool-build/SKILL.md) | Phase guidance for /tool-build |
+| [`neuroflow:phase-tool-validate`](skills/phase-tool-validate/SKILL.md) | Phase guidance for /tool-validate |
+| [`neuroflow:phase-data`](skills/phase-data/SKILL.md) | Phase guidance for /data |
+| [`neuroflow:phase-data-preprocess`](skills/phase-data-preprocess/SKILL.md) | Phase guidance for /data-preprocess |
+| [`neuroflow:phase-data-analyze`](skills/phase-data-analyze/SKILL.md) | Phase guidance for /data-analyze |
+| [`neuroflow:phase-paper-write`](skills/phase-paper-write/SKILL.md) | Phase guidance for /paper-write |
+| [`neuroflow:phase-paper-review`](skills/phase-paper-review/SKILL.md) | Phase guidance for /paper-review — delegates review to neuroflow:review-neuro |
+| [`neuroflow:phase-notes`](skills/phase-notes/SKILL.md) | Phase guidance for /notes |
+| [`neuroflow:phase-write-report`](skills/phase-write-report/SKILL.md) | Phase guidance for /write-report |
 
 ---
 

--- a/commands/data-analyze.md
+++ b/commands/data-analyze.md
@@ -8,6 +8,7 @@ reads:
   - .neuroflow/ideation/flow.md
   - .neuroflow/data-preprocess/flow.md
   - .neuroflow/data-analyze/flow.md
+  - skills/phase-data-analyze/SKILL.md
 writes:
   - .neuroflow/data-analyze/
   - .neuroflow/data-analyze/flow.md
@@ -16,7 +17,7 @@ writes:
 
 # /data-analyze
 
-Follow the neuroflow-core lifecycle: read `project_config.md`, `flow.md`, and `.neuroflow/data-analyze/flow.md` before starting. Also check `.neuroflow/ideation/` for the research question and hypothesis, and `.neuroflow/data-preprocess/` for the preprocessing report.
+Read the `neuroflow:phase-data-analyze` skill first. Then follow the neuroflow-core lifecycle: read `project_config.md`, `flow.md`, and `.neuroflow/data-analyze/flow.md` before starting. Also check `.neuroflow/ideation/` for the research question and hypothesis, and `.neuroflow/data-preprocess/` for the preprocessing report.
 
 ## What this command does
 

--- a/commands/data-preprocess.md
+++ b/commands/data-preprocess.md
@@ -7,6 +7,7 @@ reads:
   - .neuroflow/flow.md
   - .neuroflow/data/flow.md
   - .neuroflow/data-preprocess/flow.md
+  - skills/phase-data-preprocess/SKILL.md
 writes:
   - .neuroflow/data-preprocess/
   - .neuroflow/data-preprocess/flow.md
@@ -15,7 +16,7 @@ writes:
 
 # /data-preprocess
 
-Follow the neuroflow-core lifecycle: read `project_config.md`, `flow.md`, and `.neuroflow/data-preprocess/flow.md` before starting. Also check `.neuroflow/data/flow.md` to understand what data is available.
+Read the `neuroflow:phase-data-preprocess` skill first. Then follow the neuroflow-core lifecycle: read `project_config.md`, `flow.md`, and `.neuroflow/data-preprocess/flow.md` before starting. Also check `.neuroflow/data/flow.md` to understand what data is available.
 
 ## What this command does
 

--- a/commands/data.md
+++ b/commands/data.md
@@ -6,6 +6,7 @@ reads:
   - .neuroflow/project_config.md
   - .neuroflow/flow.md
   - .neuroflow/data/flow.md
+  - skills/phase-data/SKILL.md
 writes:
   - .neuroflow/data/
   - .neuroflow/data/flow.md
@@ -14,7 +15,7 @@ writes:
 
 # /data
 
-Follow the neuroflow-core lifecycle: read `project_config.md`, `flow.md`, and `.neuroflow/data/flow.md` before starting.
+Read the `neuroflow:phase-data` skill first. Then follow the neuroflow-core lifecycle: read `project_config.md`, `flow.md`, and `.neuroflow/data/flow.md` before starting.
 
 ## What this command does
 

--- a/commands/experiment.md
+++ b/commands/experiment.md
@@ -7,6 +7,7 @@ reads:
   - .neuroflow/flow.md
   - .neuroflow/ideation/flow.md
   - .neuroflow/experiment/flow.md
+  - skills/phase-experiment/SKILL.md
 writes:
   - .neuroflow/experiment/
   - .neuroflow/experiment/flow.md
@@ -15,7 +16,7 @@ writes:
 
 # /experiment
 
-Follow the neuroflow-core lifecycle: read `project_config.md`, `flow.md`, and `.neuroflow/experiment/flow.md` before starting. Also check `.neuroflow/ideation/` for research question and hypothesis.
+Read the `neuroflow:phase-experiment` skill first. Then follow the neuroflow-core lifecycle: read `project_config.md`, `flow.md`, and `.neuroflow/experiment/flow.md` before starting. Also check `.neuroflow/ideation/` for research question and hypothesis.
 
 ## What this command does
 

--- a/commands/grant-proposal.md
+++ b/commands/grant-proposal.md
@@ -7,6 +7,7 @@ reads:
   - .neuroflow/flow.md
   - .neuroflow/ideation/flow.md
   - .neuroflow/grant-proposal/flow.md
+  - skills/phase-grant-proposal/SKILL.md
 writes:
   - .neuroflow/grant-proposal/
   - .neuroflow/grant-proposal/flow.md
@@ -15,7 +16,7 @@ writes:
 
 # /grant-proposal
 
-Follow the neuroflow-core lifecycle: read `project_config.md`, `flow.md`, and `.neuroflow/grant-proposal/flow.md` before starting. Also read `.neuroflow/ideation/flow.md` if it exists — load any research question or proposal document from there.
+Read the `neuroflow:phase-grant-proposal` skill first. Then follow the neuroflow-core lifecycle: read `project_config.md`, `flow.md`, and `.neuroflow/grant-proposal/flow.md` before starting. Also read `.neuroflow/ideation/flow.md` if it exists — load any research question or proposal document from there.
 
 ## What this command does
 

--- a/commands/ideation.md
+++ b/commands/ideation.md
@@ -6,6 +6,7 @@ reads:
   - .neuroflow/project_config.md
   - .neuroflow/flow.md
   - .neuroflow/ideation/flow.md
+  - skills/phase-ideation/SKILL.md
 writes:
   - .neuroflow/ideation/
   - .neuroflow/ideation/flow.md
@@ -14,7 +15,7 @@ writes:
 
 # /ideation
 
-Follow the neuroflow-core lifecycle: read `project_config.md`, `flow.md`, and `.neuroflow/ideation/flow.md` before starting.
+Read the `neuroflow:phase-ideation` skill first. Then follow the neuroflow-core lifecycle: read `project_config.md`, `flow.md`, and `.neuroflow/ideation/flow.md` before starting.
 
 ## What this command does
 

--- a/commands/notes.md
+++ b/commands/notes.md
@@ -6,6 +6,7 @@ reads:
   - .neuroflow/project_config.md
   - .neuroflow/flow.md
   - .neuroflow/notes/flow.md
+  - skills/phase-notes/SKILL.md
 writes:
   - .neuroflow/notes/
   - .neuroflow/notes/flow.md
@@ -14,7 +15,7 @@ writes:
 
 # /notes
 
-Follow the neuroflow-core lifecycle: read `project_config.md` and `flow.md` before starting.
+Read the `neuroflow:phase-notes` skill first. Then follow the neuroflow-core lifecycle: read `project_config.md` and `flow.md` before starting.
 
 ## What this command does
 

--- a/commands/paper-review.md
+++ b/commands/paper-review.md
@@ -7,6 +7,7 @@ reads:
   - .neuroflow/flow.md
   - .neuroflow/paper-write/flow.md
   - .neuroflow/paper-review/flow.md
+  - skills/phase-paper-review/SKILL.md
 writes:
   - .neuroflow/paper-review/
   - .neuroflow/paper-review/flow.md
@@ -15,7 +16,7 @@ writes:
 
 # /paper-review
 
-Follow the neuroflow-core lifecycle: read `project_config.md`, `flow.md`, and `.neuroflow/paper-review/flow.md` before starting. Check `.neuroflow/paper-write/` for the manuscript draft.
+Read the `neuroflow:phase-paper-review` skill first. Then follow the neuroflow-core lifecycle: read `project_config.md`, `flow.md`, and `.neuroflow/paper-review/flow.md` before starting. Check `.neuroflow/paper-write/` for the manuscript draft.
 
 ## What this command does
 

--- a/commands/paper-write.md
+++ b/commands/paper-write.md
@@ -8,6 +8,7 @@ reads:
   - .neuroflow/ideation/flow.md
   - .neuroflow/data-analyze/flow.md
   - .neuroflow/paper-write/flow.md
+  - skills/phase-paper-write/SKILL.md
 writes:
   - .neuroflow/paper-write/
   - .neuroflow/paper-write/flow.md
@@ -16,7 +17,7 @@ writes:
 
 # /paper-write
 
-Follow the neuroflow-core lifecycle: read `project_config.md`, `flow.md`, and `.neuroflow/paper-write/flow.md` before starting. Load context from `.neuroflow/ideation/` (research question, hypothesis) and `.neuroflow/data-analyze/` (results summary).
+Read the `neuroflow:phase-paper-write` skill first. Then follow the neuroflow-core lifecycle: read `project_config.md`, `flow.md`, and `.neuroflow/paper-write/flow.md` before starting. Load context from `.neuroflow/ideation/` (research question, hypothesis) and `.neuroflow/data-analyze/` (results summary).
 
 ## What this command does
 

--- a/commands/tool-build.md
+++ b/commands/tool-build.md
@@ -6,6 +6,7 @@ reads:
   - .neuroflow/project_config.md
   - .neuroflow/flow.md
   - .neuroflow/tool-build/flow.md
+  - skills/phase-tool-build/SKILL.md
 writes:
   - .neuroflow/tool-build/
   - .neuroflow/tool-build/flow.md
@@ -14,7 +15,7 @@ writes:
 
 # /tool-build
 
-Follow the neuroflow-core lifecycle: read `project_config.md`, `flow.md`, and `.neuroflow/tool-build/flow.md` before starting.
+Read the `neuroflow:phase-tool-build` skill first. Then follow the neuroflow-core lifecycle: read `project_config.md`, `flow.md`, and `.neuroflow/tool-build/flow.md` before starting.
 
 ## What this command does
 

--- a/commands/tool-validate.md
+++ b/commands/tool-validate.md
@@ -8,6 +8,7 @@ reads:
   - .neuroflow/tool-build/flow.md
   - .neuroflow/experiment/flow.md
   - .neuroflow/tool-validate/flow.md
+  - skills/phase-tool-validate/SKILL.md
 writes:
   - .neuroflow/tool-validate/
   - .neuroflow/tool-validate/flow.md
@@ -16,7 +17,7 @@ writes:
 
 # /tool-validate
 
-Follow the neuroflow-core lifecycle: read `project_config.md`, `flow.md`, and `.neuroflow/tool-validate/flow.md` before starting. Also check `.neuroflow/tool-build/` and `.neuroflow/experiment/` for relevant specs and code.
+Read the `neuroflow:phase-tool-validate` skill first. Then follow the neuroflow-core lifecycle: read `project_config.md`, `flow.md`, and `.neuroflow/tool-validate/flow.md` before starting. Also check `.neuroflow/tool-build/` and `.neuroflow/experiment/` for relevant specs and code.
 
 ## What this command does
 

--- a/commands/write-report.md
+++ b/commands/write-report.md
@@ -7,6 +7,7 @@ reads:
   - .neuroflow/flow.md
   - .neuroflow/sessions/
   - .neuroflow/{phase}/flow.md    # for each phase covered in the report
+  - skills/phase-write-report/SKILL.md
 writes:
   - .neuroflow/write-report/
   - .neuroflow/write-report/flow.md
@@ -15,7 +16,7 @@ writes:
 
 # /write-report
 
-Follow the neuroflow-core lifecycle: read `project_config.md` and `flow.md` before starting.
+Read the `neuroflow:phase-write-report` skill first. Then follow the neuroflow-core lifecycle: read `project_config.md` and `flow.md` before starting.
 
 ## What this command does
 

--- a/skills/phase-data-analyze/SKILL.md
+++ b/skills/phase-data-analyze/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: phase-data-analyze
+description: Phase guidance for the neuroflow /data-analyze command. Loaded automatically when /data-analyze is invoked to orient agent behavior, relevant skills, and workflow hints for the data-analyze phase.
+---
+
+# phase-data-analyze
+
+The data-analyze phase applies statistical and computational methods to preprocessed data to test the research hypothesis.
+
+## Approach
+
+- Read `.neuroflow/ideation/` for the research question and `.neuroflow/data-preprocess/` for the preprocessing report before choosing methods
+- Write an `analysis-plan.md` first; do not write analysis code before the plan is accepted
+- Audit statistical assumptions explicitly (normality, sphericity, independence) before selecting tests
+- Apply appropriate multiple-comparison correction; if omitted, flag it and explain why
+
+## Relevant skills
+
+- `neuroflow:neuroflow-core` — read first; defines the command lifecycle and `.neuroflow/` write rules
+
+## Workflow hints
+
+- All code, results, and figures go to `output_path` (`scripts/analysis/`, `results/`, `figures/`), not inside `.neuroflow/`
+- Save `analysis-plan.md` to `.neuroflow/data-analyze/` before running any scripts
+- Log deviations from a pre-registered analysis plan in `decisions.md`

--- a/skills/phase-data-preprocess/SKILL.md
+++ b/skills/phase-data-preprocess/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: phase-data-preprocess
+description: Phase guidance for the neuroflow /data-preprocess command. Loaded automatically when /data-preprocess is invoked to orient agent behavior, relevant skills, and workflow hints for the data-preprocess phase.
+---
+
+# phase-data-preprocess
+
+The data-preprocess phase filters, cleans, epochs, and quality-checks raw data to produce analysis-ready datasets.
+
+## Approach
+
+- Read `.neuroflow/data/` inventory first — understand the dataset before choosing methods
+- Confirm the modality; preprocessing steps differ significantly between EEG, fMRI, ECG, eye-tracking
+- Document every parameter choice (filter cutoffs, epoch windows, rejection thresholds) before running
+- QC plots and rejection summaries are required outputs — not optional
+
+## Relevant skills
+
+- `neuroflow:neuroflow-core` — read first; defines the command lifecycle and `.neuroflow/` write rules
+
+## Workflow hints
+
+- All scripts and processed data go to `output_path` (`scripts/preprocessing/`), not inside `.neuroflow/`
+- Save `preprocess-config.md` to `.neuroflow/data-preprocess/` with the full parameter set used
+- Log any deviation from a pre-registered preprocessing plan in `decisions.md`

--- a/skills/phase-data/SKILL.md
+++ b/skills/phase-data/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: phase-data
+description: Phase guidance for the neuroflow /data command. Loaded automatically when /data is invoked to orient agent behavior, relevant skills, and workflow hints for the data intake phase.
+---
+
+# phase-data
+
+The data phase locates raw data, validates BIDS structure, and runs conversion scripts to get data ready for preprocessing.
+
+## Approach
+
+- Follow the three-step sequence in order: inventory → validate → convert — do not skip ahead
+- Confirm data location and expected modality before doing anything
+- BIDS compliance is the target; note deviations but do not block progress for minor issues
+- Summarize what was found, what passed, and what needs fixing before moving on
+
+## Relevant skills
+
+- `neuroflow:neuroflow-core` — read first; defines the command lifecycle and `.neuroflow/` write rules
+
+## Workflow hints
+
+- Save `data-inventory.md` to `.neuroflow/data/` listing datasets, paths, and BIDS status
+- Conversion scripts and outputs go to `output_path`, not inside `.neuroflow/`
+- Log any structural data issues discovered in `decisions.md` if they affect analysis choices downstream

--- a/skills/phase-experiment/SKILL.md
+++ b/skills/phase-experiment/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: phase-experiment
+description: Phase guidance for the neuroflow /experiment command. Loaded automatically when /experiment is invoked to orient agent behavior, relevant skills, and workflow hints for the experiment phase.
+---
+
+# phase-experiment
+
+The experiment phase covers paradigm design, recording setup, and instrument configuration — everything needed before data collection begins.
+
+## Approach
+
+- Identify which sub-task applies (paradigm design, recording setup, instrument config) and handle one at a time
+- Read `.neuroflow/ideation/` for the research question and hypothesis before designing anything
+- Confirm modality (EEG, fMRI, eye-tracking, ECG, etc.) early; it constrains all downstream decisions
+- Write a brief design rationale — not just the implementation
+
+## Relevant skills
+
+- `neuroflow:neuroflow-core` — read first; defines the command lifecycle and `.neuroflow/` write rules
+
+## Workflow hints
+
+- PsychoPy scripts and config files go to `output_path` (`paradigm/`), not inside `.neuroflow/`
+- Save `experiment-plan.md` to `.neuroflow/experiment/` covering design choices and recording parameters
+- Log any paradigm design decision that deviates from the pre-registered plan in `decisions.md`

--- a/skills/phase-grant-proposal/SKILL.md
+++ b/skills/phase-grant-proposal/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: phase-grant-proposal
+description: Phase guidance for the neuroflow /grant-proposal command. Loaded automatically when /grant-proposal is invoked to orient agent behavior, relevant skills, and workflow hints for the grant-proposal phase.
+---
+
+# phase-grant-proposal
+
+The grant-proposal phase translates a defined research question into a fundable proposal for a specific funding body.
+
+## Approach
+
+- Read `.neuroflow/ideation/` outputs before starting — the research question and any literature must exist first
+- Ask about the funder, scheme, and page/word limits before drafting anything
+- Structure the proposal section by section; do not write all sections in one pass
+- Align significance and innovation language to the funder's stated priorities
+
+## Relevant skills
+
+- `neuroflow:neuroflow-core` — read first; defines the command lifecycle and `.neuroflow/` write rules
+
+## Workflow hints
+
+- All drafted content (aims, narrative, budget tables) goes to `output_path` (`grant/`), not inside `.neuroflow/`
+- Save a brief grant summary to `.neuroflow/grant-proposal/` so future commands know funding context
+- Log funder, scheme, and deadline in `project_config.md` if not already there

--- a/skills/phase-ideation/SKILL.md
+++ b/skills/phase-ideation/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: phase-ideation
+description: Phase guidance for the neuroflow /ideation command. Loaded automatically when /ideation is invoked to orient agent behavior, relevant skills, and workflow hints for the ideation phase.
+---
+
+# phase-ideation
+
+The ideation phase is the entry point of a research project — sharpening a vague idea into a testable research question.
+
+## Approach
+
+- Identify which entry point applies (brainstorm, literature explore, formalize, proposal) before doing anything else
+- Resist generating a full proposal before the research question is clear — sequence matters
+- Use the `scholar` agent for any literature search; do not search manually
+- Keep outputs hypothesis-driven and concise; avoid scope creep at this stage
+- If `project_config.md` already has a research question, confirm whether to refine or restart
+
+## Relevant skills
+
+- `neuroflow:neuroflow-core` — read first; defines the command lifecycle and `.neuroflow/` write rules
+
+## Workflow hints
+
+- The research question produced here anchors every downstream phase — write it precisely
+- Save the final research question to `.neuroflow/ideation/research-question.md`
+- Update `project_config.md` if the research question is defined or changed

--- a/skills/phase-notes/SKILL.md
+++ b/skills/phase-notes/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: phase-notes
+description: Phase guidance for the neuroflow /notes command. Loaded automatically when /notes is invoked to orient agent behavior, relevant skills, and workflow hints for the notes phase.
+---
+
+# phase-notes
+
+The notes phase captures live notes during a meeting, talk, or session, then reformats them into a clean structured document.
+
+## Approach
+
+- Accept freeform input without correcting or restructuring until the user signals they are done
+- Do not prompt for formatting, completeness, or clarification during capture — just record
+- Only reformat when explicitly asked, or when the user signals the session is over
+
+## Relevant skills
+
+- `neuroflow:neuroflow-core` — read first; defines the command lifecycle and `.neuroflow/` write rules
+
+## Workflow hints
+
+- Save the final formatted notes to `.neuroflow/notes/notes-[date].md`
+- Keep the raw capture separate from the reformatted version if both are useful

--- a/skills/phase-paper-review/SKILL.md
+++ b/skills/phase-paper-review/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: phase-paper-review
+description: Phase guidance for the neuroflow /paper-review command. Loaded automatically when /paper-review is invoked to orient agent behavior, relevant skills, and workflow hints for the paper-review phase.
+---
+
+# phase-paper-review
+
+The paper-review phase runs a rigorous pre-submission peer review of a neuroscience manuscript.
+
+## Approach
+
+- Gather all three inputs (manuscript, target journal, specific focus or full review) before invoking the review skill
+- Delegate the entire review procedure to `neuroflow:review-neuro` — do not conduct the review independently
+- Check `.neuroflow/paper-write/` for the current draft before asking the user where the manuscript is
+
+## Relevant skills
+
+- `neuroflow:neuroflow-core` — read first; defines the command lifecycle and `.neuroflow/` write rules
+- `neuroflow:review-neuro` — invoke this skill to perform the review; pass manuscript, journal, and focus as inputs
+
+## Workflow hints
+
+- The review is saved automatically by `review-neuro` to `.neuroflow/paper-review/review-[date].md` — do not duplicate this
+- Append only a single one-liner to the session log referencing the saved file path

--- a/skills/phase-paper-write/SKILL.md
+++ b/skills/phase-paper-write/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: phase-paper-write
+description: Phase guidance for the neuroflow /paper-write command. Loaded automatically when /paper-write is invoked to orient agent behavior, relevant skills, and workflow hints for the paper-write phase.
+---
+
+# phase-paper-write
+
+The paper-write phase generates a manuscript draft from analysis results, figures, and project memory accumulated across all prior phases.
+
+## Approach
+
+- Read upstream phase flows (ideation, data-analyze, experiment) before drafting — pull facts from memory, not from recall
+- Confirm the target journal before writing; it determines structure, length, and style
+- Draft section by section in logical order; write the abstract last
+- Distinguish what the results show from what they mean — keep interpretation in Discussion
+
+## Relevant skills
+
+- `neuroflow:neuroflow-core` — read first; defines the command lifecycle and `.neuroflow/` write rules
+
+## Workflow hints
+
+- The manuscript draft goes to `output_path` (`manuscript/`), not inside `.neuroflow/`
+- Save `manuscript-plan.md` to `.neuroflow/paper-write/` with journal target, section outline, and author list
+- Log any framing or scope decisions in `decisions.md` if they differ from the original research question

--- a/skills/phase-tool-build/SKILL.md
+++ b/skills/phase-tool-build/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: phase-tool-build
+description: Phase guidance for the neuroflow /tool-build command. Loaded automatically when /tool-build is invoked to orient agent behavior, relevant skills, and workflow hints for the tool-build phase.
+---
+
+# phase-tool-build
+
+The tool-build phase designs and implements lab tools or software pipelines — real-time systems, data acquisition, LSL integrations, or custom analysis pipelines.
+
+## Approach
+
+- Define done-criteria and the tool specification before writing any code
+- Ask which type of tool is needed (acquisition, real-time processing, LSL, analysis pipeline, other)
+- Write `tool-spec.md` first; get confirmation before implementation begins
+- Prefer tested, modular components over monolithic scripts
+
+## Relevant skills
+
+- `neuroflow:neuroflow-core` — read first; defines the command lifecycle and `.neuroflow/` write rules
+
+## Workflow hints
+
+- All code goes to `output_path` (`tools/`), not inside `.neuroflow/`
+- Save `tool-spec.md` to `.neuroflow/tool-build/` before writing any implementation
+- Note key technical decisions (library choice, architecture, interfaces) in `decisions.md`

--- a/skills/phase-tool-validate/SKILL.md
+++ b/skills/phase-tool-validate/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: phase-tool-validate
+description: Phase guidance for the neuroflow /tool-validate command. Loaded automatically when /tool-validate is invoked to orient agent behavior, relevant skills, and workflow hints for the tool-validate phase.
+---
+
+# phase-tool-validate
+
+The tool-validate phase creates and runs a testing pipeline to verify that a tool or paradigm works correctly — timing, markers, data output, and edge cases.
+
+## Approach
+
+- Read `.neuroflow/tool-build/` outputs before planning validation — understand what was built first
+- Write a `validation-plan.md` before running any tests
+- Cover timing accuracy, marker integrity, data output format, and known edge cases
+- Report results objectively — include failures, not just passes
+
+## Relevant skills
+
+- `neuroflow:neuroflow-core` — read first; defines the command lifecycle and `.neuroflow/` write rules
+
+## Workflow hints
+
+- Test scripts and logs go to `output_path` (`tools/`), not inside `.neuroflow/`
+- Save `validation-report-[date].md` to `.neuroflow/tool-validate/` summarizing pass/fail status
+- If validation reveals a design flaw, log the finding in `decisions.md` and loop back to tool-build

--- a/skills/phase-write-report/SKILL.md
+++ b/skills/phase-write-report/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: phase-write-report
+description: Phase guidance for the neuroflow /write-report command. Loaded automatically when /write-report is invoked to orient agent behavior, relevant skills, and workflow hints for the write-report phase.
+---
+
+# phase-write-report
+
+The write-report phase generates a structured report from `.neuroflow/` contents — for a specific phase, multiple phases, or the whole project.
+
+## Approach
+
+- Confirm scope (which phase(s)), audience, and depth before loading any files
+- Use `flow.md` files to navigate `.neuroflow/` rather than reading all content up front
+- Synthesize across phases when the report spans multiple — do not list files, narrate progress
+
+## Relevant skills
+
+- `neuroflow:neuroflow-core` — read first; defines the command lifecycle and `.neuroflow/` write rules
+
+## Workflow hints
+
+- Save the report to `results/` or the phase folder specified by the user — confirm `output_path` before writing
+- Keep the report concise; a summary of key decisions and outputs is more useful than exhaustive detail


### PR DESCRIPTION
- Add 12 new phase skills (data, experiment, ideation, notes, paper-review, paper-write, grant-proposal, tool-build, tool-validate, write-report, data-preprocess, data-analyze)
- Update all corresponding commands with revised frontmatter and content
- Update README tables to include new phase skills
- Update plugin.json and bump version to 0.1.2
- Update sentinel-dev audit report