### PR TITLE
feat: v0.2.5 — /poster command, gws setup battle-tested, sentinel Che…

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "neuroflow",
       "source": "./",
       "description": "End-to-end research workflow plugin for neuroscience teams — from hypothesis to publication. Supports EEG, iEEG, fMRI, eye tracking, ECG, and multimodal recordings.",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "author": {
         "name": "Stanislav Jiricek"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neuroflow",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "End-to-end research workflow plugin for neuroscience teams — from hypothesis to publication. Supports EEG, iEEG, fMRI, eye tracking, ECG, and other neuroscience modalities.",
   "author": {
     "name": "Stanislav Jiricek"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@
 
 ---
 
+## What's new in 0.2.5
+
+- **[`/poster`](commands/poster.md)** — generate a LaTeX conference poster from project memory; five templates (A0/A1 portrait, A0 landscape, 90×120 cm, 48×36 in); QR code support via the `qrcode` package; iterative `poster-critic` review loop (up to 3 cycles) before the `.tex` file is saved
+- **New [`poster-critic`](agents/poster-critic.md) agent** — audits every poster draft across five areas (content accuracy, visual balance, scientific communication, QR code, LaTeX correctness); returns `[STATUS: APPROVED]` or `[STATUS: REJECTED]` with specific, actionable feedback; never rewrites content
+- **New [`neuroflow:phase-poster`](skills/phase-poster/SKILL.md) skill** — full LaTeX template catalogue with embedded QR code blocks, template selection guide, content extraction logic, and compilation instructions
+
 ## What's new in 0.2.4
 
 - **Sentinel Check 3b** — sentinel now validates that `.claude-plugin/marketplace.json` version matches `plugin.json`; the marketplace version was silently stuck at `0.1.0` with no existing check to catch it
@@ -149,7 +155,7 @@ Run `/neuroflow:<command>` in any project folder. Start with `/neuroflow:neurofl
 | Command | What it does |
 |---|---|
 | [`/neuroflow`](commands/neuroflow.md) | Main entry point — if `.neuroflow/` exists, shows current phase and status; if not, interviews the user and creates the project memory structure |
-| [`/setup`](commands/setup.md) | Interactive credential wizard — configure PubMed email and Miro access token; saves to `.neuroflow/integrations.json` |
+| [`/setup`](commands/setup.md) | Interactive credential wizard — configure PubMed email, Miro access token, and Google Workspace CLI; saves to `.neuroflow/integrations.json` |
 
 ### Research pipeline
 
@@ -188,6 +194,7 @@ Run `/neuroflow:<command>` in any project folder. Start with `/neuroflow:neurofl
 | [`/phase`](commands/phase.md) | Show current phase and all phases worked on; optionally switch phase |
 | [`/sentinel`](commands/sentinel.md) | Full audit of `.neuroflow/` — drift detection, broken references, preregistration vs progress |
 | [`/slideshow`](commands/slideshow.md) | Build a presentation from selected areas of the project — pick phases, figures, and key findings, then get a structured slide deck ready to export |
+| [`/poster`](commands/poster.md) | Generate a LaTeX conference poster from project memory — choose template size, add a QR code, and get an iteratively reviewed `.tex` file ready to compile |
 | [`/quiz`](commands/quiz.md) | Neuroscience quiz — flashcards, pub quiz, or rapid-fire throw questions; covers any subfield or general neuroscience |
 | [`/fails`](commands/fails.md) | Log dissatisfaction — record core behavior, science quality, or UX issues; optionally opens a GitHub issue report |
 | [`/output`](commands/output.md) | Output project memory or the whole project — pack as a zip archive or copy to a folder for sharing, archiving, or handoff |
@@ -232,6 +239,7 @@ Skills are invoked by Claude automatically when relevant, or triggered explicitl
 | [`neuroflow:phase-search`](skills/phase-search/SKILL.md) | Phase guidance for /search — tag-based scoping, flow.md-first indexing strategy, compact summary format |
 | [`neuroflow:phase-pipeline`](skills/phase-pipeline/SKILL.md) | Phase guidance for /pipeline — interactive vs brutal mode behaviour, pipeline plan format, resume logic, error handling |
 | [`neuroflow:phase-flowie`](skills/phase-flowie/SKILL.md) | Phase guidance for /flowie — profile read and apply rules, write rules for `.neuroflow/.flowie/`, GitHub sync protocol, cross-phase personalization |
+| [`neuroflow:phase-poster`](skills/phase-poster/SKILL.md) | LaTeX poster generation — five templates (A0/A1/A2, portrait/landscape, US size), QR code integration, template selection guide, content extraction logic |
 
 ---
 
@@ -263,6 +271,7 @@ Agents are autonomous subprocesses launched by commands when deeper, focused wor
 | [`brain-optimize`](agents/brain-optimize.md) | Parameter optimisation specialist — plans sweeps or data-fitting runs; selects the right algorithm (grid, differential evolution, Bayesian, BluePyOpt) |
 | [`brain-run`](agents/brain-run.md) | Simulation runner — configures and executes runs, sanity-checks outputs for silence, runaway activity, or NaN values; supports HPC job submission |
 | [`neuroflow-developer`](.github/agents/neuroflow-developer.md) | Superspecialized plugin development agent — merges neuroflow-core and neuroflow-develop into one repo-aware agent; reads live repo state at session start; handles skills, commands, agents, hooks, docs, and releases |
+| [`poster-critic`](agents/poster-critic.md) | Conference poster critic — audits every LaTeX poster draft across five areas (content, layout, scientific communication, QR code, LaTeX correctness); returns APPROVED or REJECTED with actionable feedback; operates inside the /poster worker-critic loop |
 | [`flowie`](agents/flowie.md) | Personal identity agent — reads the user's flowie profile and applies their research stances, writing style, and methodological preferences throughout the session; never exposes profile data in external-facing outputs |
 
 ---
@@ -350,12 +359,21 @@ neuroflow uses four MCP servers that Claude Code launches automatically via `npx
 | Miro | `@k-jarzyna/mcp-miro` | `MIRO_ACCESS_TOKEN` — personal access token from Miro |
 | Context7 | `@upstash/context7-mcp` | none |
 
+neuroflow also supports an optional **Google Workspace CLI** (`gws`) for Gmail, Calendar, Drive, Sheets, and more. It is separate from the MCP servers and must be installed manually:
+
+| Tool | Install | Credentials needed |
+|---|---|---|
+| Google Workspace CLI | `npm install -g @googleworkspace/cli` (requires Node.js 18+) | OAuth client_secret.json from Google Cloud Console → `GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE` |
+
+> **Note:** `gws auth setup` requires the `gcloud` CLI. If `gcloud` is not installed, use the manual OAuth path: create credentials in [Google Cloud Console](https://console.cloud.google.com), download `client_secret.json`, place it at `~/.config/gws/client_secret.json`, and run `gws auth login`.
+
 ### Setup wizard
 
 Run `/neuroflow:setup` (or answer **Y** when prompted during `/neuroflow:neuroflow`) to enter a guided wizard:
 
 1. **PubMed** — enter your email address. Validated for `@` format. Skippable.
 2. **Miro** — paste a personal access token from your [Miro developer settings](https://miro.com/app/settings/user-profile/apps). Skippable.
+3. **Google Workspace CLI** — checks if `gws` is installed; offers to install via npm if not; guides through the manual OAuth credential path (no `gcloud` required). Skippable.
 
 Credentials are saved to **`.neuroflow/integrations.json`** in your project folder. This file is excluded from git (see `.gitignore`) so it is never committed.
 
@@ -366,6 +384,7 @@ After running `/setup`, export the env vars in your shell before starting Claude
 ```bash
 export PUBMED_EMAIL="you@example.com"
 export MIRO_ACCESS_TOKEN="eyJ..."
+export GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE="$HOME/.config/gws/client_secret.json"
 ```
 
 Add these to your shell profile (`~/.zshrc`, `~/.bashrc`) so they load automatically on every session.
@@ -380,6 +399,8 @@ Alternatively, you can set the env vars directly without running the wizard — 
 | PubMed email entry | ✅ Prompted by `/setup` wizard | — |
 | Miro token entry | ✅ Prompted by `/setup` wizard | ⚠️ You must create the token in the Miro browser UI first |
 | Miro OAuth browser login | ❌ Not implemented (by design — browser OAuth from a terminal subprocess is not feasible without a redirect server) | Use a personal access token instead |
+| Google Workspace CLI install | ✅ `/setup` wizard can run `npm install -g` if you confirm | Requires Node.js 18+ |
+| Google Workspace OAuth | ❌ `gws auth setup` requires `gcloud` CLI | Manual path: download `client_secret.json` from GCP Console, run `gws auth login` |
 | Env var export | ❌ Not automatic | Run `export …` or add to shell profile |
 
 ### Reminder behavior

--- a/agents/poster-critic.md
+++ b/agents/poster-critic.md
@@ -1,0 +1,146 @@
+---
+name: poster-critic
+description: Hyper-critical academic conference poster reviewer. Evaluates LaTeX poster `.tex` source against design, content, and communication standards. Returns [STATUS: APPROVED] or [STATUS: REJECTED] with specific, actionable feedback. Used by /poster in the iterative worker-critic loop (max 3 cycles). Never produces content — only audits.
+---
+
+# poster-critic
+
+Autonomous critic agent for the neuroflow poster phase. Reviews every draft of the LaTeX poster source against a five-area rubric — content accuracy, visual balance, legibility, scientific communication, and technical correctness — before the `.tex` file is saved. Operates inside the `/poster` worker-critic loop; returns a structured verdict after every draft.
+
+---
+
+## Role
+
+Evaluate the poster `.tex` source against the rubric provided by the orchestrator. The critic does not produce content — it audits content. It does not rewrite LaTeX — it specifies exactly what must change and where.
+
+---
+
+## Review rubric (five areas)
+
+### Area 1 — Content accuracy and completeness
+
+- Title must clearly convey the research question or key finding (not just a topic label)
+- Authors and affiliations must be present and complete
+- Introduction must state the scientific gap (not just background)
+- Objectives / aims must be explicitly stated (not implied from the methods)
+- Methods must include: participant count (N), modality/instrument, and at least one sentence on the analysis approach
+- Results must include at least one specific finding with a numerical value (effect size, p-value, or percentage) — not only "we found a significant difference"
+- Conclusions must directly address the stated objectives
+- References section must be present with at least 2 citations
+
+### Area 2 — Visual balance and layout
+
+- Column proportions must be appropriate for the content density — a column that is substantially emptier than its neighbours is a layout problem
+- No section may be empty or contain only the word "PLACEHOLDER" without a visible note to the reader
+- The title block must be visually dominant (large font, high-contrast background)
+- Results section should occupy the largest single block or be equivalent to Introduction + Methods combined
+- Footer / bottom block should contain: contact information AND (if requested) the QR code
+
+### Area 3 — Scientific communication quality
+
+- Each result must be stated as a claim, not as a procedural description ("Group A showed higher N200 amplitude than Group B [t(38) = 2.4, p = 0.02, d = 0.76]" not "we ran a t-test and found significance")
+- Figures must have captions — `\includegraphics` stubs must include a `\par\small Figure N. ...` caption line
+- Causality language must match the study design — flag "X drives Y" if the study is observational/correlational
+- Jargon density must be appropriate for the stated conference audience; highly technical abbreviations must be defined at first use
+
+### Area 4 — QR code and contact information
+
+- If a QR code was requested: the `\qrcode{}` command must be present in the footer block with a non-placeholder URL
+- If a QR code was requested but the URL is still the template placeholder (`https://doi.org/10.XXXX/XXXXX`): flag as unresolved placeholder
+- Contact email must be present (either in the footer block or the title block)
+
+### Area 5 — LaTeX technical correctness
+
+- `\begin{document}` and `\end{document}` must be present
+- `\maketitle` must be called after `\begin{document}`
+- Column fractions in `\begin{columns}` must sum to ≤ 1.0 (flag if they sum to > 1.05 — tikzposter will silently overflow)
+- Required packages must be in the preamble: `tikzposter`, `qrcode` (if QR code is used), `graphicx`
+- No unclosed environments (e.g., a `\begin{itemize}` without matching `\end{itemize}`)
+- No undefined commands (obvious indicators: `\textit` used as `\textit` is fine; watch for novel undefined macros introduced by the worker)
+
+---
+
+## Output format (strict)
+
+Every response must begin with exactly one of:
+
+```
+[STATUS: APPROVED]
+```
+
+or
+
+```
+[STATUS: REJECTED]
+```
+
+### On APPROVED
+
+A brief 1–2 sentence statement confirming which of the five areas were checked and noting any minor points the poster author should be aware of but which do not block approval.
+
+Example:
+
+```
+[STATUS: APPROVED]
+All five review areas checked. Content is accurate and complete, layout is balanced across three columns, results state specific numerical findings, QR code is present with a valid URL, and LaTeX structure is technically correct. Minor: consider expanding the figure 2 caption from "ERP result" to a one-sentence informative description.
+```
+
+### On REJECTED
+
+Follow the status token **immediately** with a bulleted list of specific, actionable fixes — no prose preamble before the bullets. Every item must name the exact LaTeX block, section, or line content and state what the correct form should be.
+
+Example:
+
+```
+[STATUS: REJECTED]
+- Content (Area 1): Results block — "we found a significant difference" must be replaced with a specific claim: state the comparison groups, the test statistic, p-value, and effect size (e.g., "N200 amplitude was larger in Group A than B [t(38) = 2.4, p = 0.02, d = 0.76]")
+- Layout (Area 2): Column 3 is empty except for the Conclusions block — move the References block from Column 1 footer to Column 3 to balance content density
+- QR (Area 4): \qrcode{} contains the template placeholder URL "https://doi.org/10.XXXX/XXXXX" — replace with the actual preprint or project URL provided by the user
+- LaTeX (Area 5): Column fractions sum to 1.34 (0.33 + 0.34 + 0.67) — must sum to ≤ 1.0; reduce Column 3 width from 0.67 to 0.33
+```
+
+---
+
+## Subsequent rounds (iterations 2 and 3)
+
+When evaluating a revised draft:
+
+1. Compare the new `.tex` source against the previously-rejected version
+2. Explicitly confirm which items from the prior feedback list were addressed — state these with a ✓
+3. Flag only items that remain unresolved
+4. Do not add new requirements as grounds for rejection unless a **newly introduced error** not present in any previous draft creates a clear content or technical problem
+
+Example iteration 2 response:
+
+```
+[STATUS: REJECTED]
+Addressed from iteration 1:
+- ✓ Results now states specific values: "N200 amplitude was larger in Group A than B [t(38) = 2.4, p = 0.02, d = 0.76]"
+- ✓ Column fractions corrected to 0.33 + 0.34 + 0.33 = 1.00
+
+Still unresolved:
+- QR (Area 4): \qrcode{} URL is still the template placeholder — must be replaced with the actual URL
+```
+
+---
+
+## What the critic does not do
+
+- Does not produce or rewrite LaTeX content
+- Does not give vague feedback ("improve the layout", "make it clearer") — every item must name the exact block/command and specify the correction
+- Does not skip any of the five areas
+- Does not invent new requirements in iterations 2 and 3 beyond newly introduced errors
+- Does not return ambiguous verdicts — every response is either `[STATUS: APPROVED]` or `[STATUS: REJECTED]`, never conditional or partial
+- Does not comment on figure content (the critic cannot see rendered images — it can only flag missing captions or stubs)
+
+---
+
+## Standards
+
+A poster is approved only if it would be accepted without embarrassment at the target conference. The bar is not "complete LaTeX" — it is "ready to send to the print shop". Do not approve:
+
+- Any poster where the Results section contains no specific numerical findings
+- Any poster with uncorrected causality overclaims relative to the study design
+- Any poster where the QR code URL is still a template placeholder (if QR was requested)
+- Any poster with LaTeX column fractions summing to > 1.05 (will overflow at compile time)
+- Any poster where the title does not convey the research question or key finding

--- a/agents/sentinel-dev.md
+++ b/agents/sentinel-dev.md
@@ -29,9 +29,19 @@ Flag missing entries and dead links.
 
 ### 3 — Version sync
 
-Read the version from `.claude-plugin/plugin.json`. Check that the same version appears in the `## What's new in X.Y.Z` heading in `README.md`.
+Read the version from `.claude-plugin/plugin.json`. Check that the same version appears in:
 
-Flag if they differ.
+- The `## What's new in X.Y.Z` heading in `README.md`
+- The `extra.version` field in `mkdocs.yml` (also covered by Check 9a)
+- The `sa-bar-version` span in `docs/index.md` — search for `class="sa-bar-version"` and extract the version text inside it
+
+Flag if any of the three differ from `plugin.json`.
+
+**3b — Self-assessment bar sync:**
+
+Read `docs/index.md`. Find the element with `class="sa-bar-version"` and extract its text content (e.g. `v0.2.5`). Strip the leading `v` and compare to the version in `.claude-plugin/plugin.json`.
+
+Flag if they differ. This check exists because the self-assessment bar must be updated on every release and is the item most commonly missed during manual releases.
 
 ### 4 — Dead references inside SKILL.md files
 

--- a/commands/poster.md
+++ b/commands/poster.md
@@ -1,0 +1,154 @@
+---
+name: poster
+description: Generate a LaTeX academic conference poster from project memory. Selects a template (A0/A1/A2, portrait/landscape, custom sizes), injects project content, adds a QR code, and runs the result through the poster-critic agent in an iterative review loop.
+phase: poster
+reads:
+  - .neuroflow/project_config.md
+  - .neuroflow/flow.md
+  - .neuroflow/ideation/flow.md
+  - .neuroflow/data-analyze/flow.md
+  - .neuroflow/paper/flow.md
+  - .neuroflow/preregistration/flow.md
+writes:
+  - .neuroflow/poster/poster-YYYY-MM-DD.tex
+  - .neuroflow/poster/critic-log.md
+  - .neuroflow/sessions/YYYY-MM-DD.md
+---
+
+# /poster
+
+Generate a publication-ready academic conference poster as a LaTeX `.tex` file from the project's `.neuroflow/` memory. The poster goes through an iterative critic loop (up to 3 revision cycles) before final output.
+
+---
+
+## Step 1 — Read project state
+
+1. Read `.neuroflow/project_config.md` to get: project title, PI name, affiliation(s), modality, research question, and any configured target conference.
+2. Check `.neuroflow/poster/` — if a previous poster exists, ask whether to start fresh or revise the latest version.
+3. Scan for available content sources (read their `flow.md` index files, not the full content):
+   - `.neuroflow/ideation/` — hypotheses, key references
+   - `.neuroflow/data-analyze/` — key results, figure paths
+   - `.neuroflow/preregistration/` — objectives and analysis plan
+   - `.neuroflow/paper/` — abstract and conclusions if a draft exists
+4. List any figure files referenced in the flow.md files.
+
+---
+
+## Step 2 — Confirm poster configuration
+
+Ask the user (if not already specified as arguments):
+
+1. **Conference name** — e.g. "SfN 2025", "OHBM 2025", "Bernstein Conference"
+2. **Poster size** — offer the template catalogue:
+   - `A` — A0 Portrait (841 × 1189 mm) — most European conferences
+   - `B` — A0 Landscape (1189 × 841 mm) — wide-format boards
+   - `C` — A1 Portrait (594 × 841 mm) — seminars, lab retreats
+   - `D` — Custom 90 × 120 cm Portrait
+   - `E` — 48 × 36 in Landscape (US conferences)
+   - `custom` — user specifies dimensions
+3. **QR code URL** — preprint DOI, OSF page, GitHub repo, or "skip" to omit
+4. **Authors and affiliations** — confirm or update from `project_config.md`
+5. **Which sections to include** — all five standard sections (Introduction, Methods, Results, Discussion/Conclusions, References) or a subset
+
+If the user gives a conference name, infer the likely size (e.g., SfN → A0 portrait or 48×36 in; OHBM → A0 portrait; NeurIPS → custom; COSYNE → 48×36 in) and confirm.
+
+---
+
+## Step 3 — Extract content from project memory
+
+Read the relevant `.neuroflow/` files identified in Step 1. Extract:
+
+- **Title** — from `project_config.md`; rephrase into a poster-appropriate punchy title if needed
+- **Introduction** — from ideation phase: background, gap, motivation (3–4 sentences maximum per paragraph; compress ruthlessly)
+- **Objectives** — from ideation or preregistration: 2–4 bullet points
+- **Methods** — from experiment, data, or analysis phase: participants (N, demographics), design, recording, key analysis steps
+- **Results** — from data-analyze phase: top 2–3 findings with effect sizes; list figure paths as `\includegraphics` stubs
+- **Conclusions** — from paper or ideation phase: 3 bullet points maximum
+- **References** — top 3–5 references most relevant to the poster (extract from ideation flow.md or paper references)
+- **Acknowledgements / funding** — from project_config.md or grant-proposal phase if available
+
+If a section has no data in `.neuroflow/`, insert a clearly marked placeholder (`PLACEHOLDER: ...`) and note it to the user.
+
+---
+
+## Step 4 — Generate LaTeX source
+
+Using the `neuroflow:phase-poster` skill:
+
+1. Select the template matching the user's choice from the template catalogue
+2. Substitute all placeholder values with extracted content
+3. Set the QR code URL (or remove the QR block if the user said "skip")
+4. For each result figure, generate a `\includegraphics` stub with the extracted path and a placeholder caption
+5. Produce the complete `.tex` file content
+
+Show the user a preview summary:
+```
+Title: <extracted title>
+Authors: <authors>
+Sections: Introduction / Methods / Results (N figures) / Discussion / Conclusions / References
+QR code: <URL or "none">
+Template: <letter> — <size description>
+```
+
+Ask: "Generate this poster? (Y/n)"
+
+---
+
+## Step 5 — Iterative critic review loop
+
+Once the user confirms, activate the worker-critic loop following `neuroflow:worker-critic`:
+
+**Worker:** the poster generator (this command, operating on the `.tex` source)
+**Critic:** the `poster-critic` agent
+**Max iterations:** 3
+
+**Iteration 1:** Pass the generated `.tex` source to `poster-critic` with the rubric:
+- Content accuracy vs project memory
+- Section balance and column proportions
+- Poster legibility (font sizes, colour contrast, title prominence)
+- QR code presence and placement (if requested)
+- Figure stubs clearly labelled
+- References present
+- No blank or placeholder sections visible in the poster except explicitly noted ones
+
+**On REJECTED:** Apply the critic's specific feedback bullets to the `.tex` source and resubmit.
+
+**On APPROVED** (or after 3 iterations): proceed to Step 6.
+
+Write the critic loop state to `.neuroflow/poster/critic-log.md` after each iteration.
+
+---
+
+## Step 6 — Save and report
+
+1. Create `.neuroflow/poster/` if it does not exist.
+2. Write the final `.tex` to `.neuroflow/poster/poster-YYYY-MM-DD.tex`. If the file exists, use `-v2`, `-v3`, etc.
+3. Write `.neuroflow/poster/critic-log.md` with the full loop history.
+4. Update `.neuroflow/flow.md` — add a `poster` entry with date and output path.
+
+Tell the user:
+
+> **Poster saved:** `.neuroflow/poster/poster-YYYY-MM-DD.tex`
+>
+> **To compile:**
+> ```bash
+> cd .neuroflow/poster
+> pdflatex poster-YYYY-MM-DD.tex
+> ```
+> Or with latexmk: `latexmk -pdf poster-YYYY-MM-DD.tex`
+>
+> **Required LaTeX packages:** `tikzposter`, `qrcode`, `graphicx`, `booktabs`, `amsmath` (all in TeX Live ≥ 2020 / MiKTeX).
+>
+> **Figure stubs:** Replace each `\includegraphics{figures/...}` stub with the actual file. Use `.pdf` or `.eps` for vector figures.
+
+If the critic loop halted at max iterations without approval, also say:
+
+> **Note:** The critic loop reached the maximum 3 iterations without full approval. Unresolved issues are logged in `.neuroflow/poster/critic-log.md`. The current `.tex` is a working draft — review the critic log and make manual edits before printing.
+
+---
+
+## Step 7 — Suggest next step
+
+- If the conference deadline is within 2 weeks (if known from `project_config.md`): remind the user to print at least 2 business days before the conference.
+- Suggest `/neuroflow:slideshow` if the user also needs a talk for the same conference.
+- Suggest `/neuroflow:paper` if the poster results are ready to be written up as a manuscript.

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -1,6 +1,6 @@
 ---
 name: setup
-description: Interactive credential wizard for neuroflow MCP integrations. Checks PubMed and Miro credentials, prompts for missing values, and saves them to .neuroflow/integrations.json.
+description: Interactive credential wizard for neuroflow MCP integrations. Checks PubMed, Miro, and Google Workspace CLI credentials, prompts for missing values, and saves them to .neuroflow/integrations.json.
 phase: utility
 reads:
   - .neuroflow/integrations.json
@@ -18,17 +18,21 @@ Guide the user through connecting the neuroflow MCP integrations. This command c
 
 Check whether `.neuroflow/integrations.json` exists. If it does, read it. Note which credentials are already set.
 
-Also check whether the environment variables `PUBMED_EMAIL` and `MIRO_ACCESS_TOKEN` are set in the current shell (you can tell by whether the MCP servers are responding). If they are already set via env vars, note that for the user.
+Also check whether the environment variables `PUBMED_EMAIL`, `MIRO_ACCESS_TOKEN`, and `GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE` are set in the current shell. If they are already set via env vars, note that for the user.
+
+Run `gws --version 2>/dev/null` (or `which gws`) to detect whether the Google Workspace CLI is installed.
 
 Display a status table:
 
 ```
-Integration   Status
-───────────   ──────
-PubMed        ✅ configured  (or ❌ not configured)
-bioRxiv       ✅ no credentials needed
-Miro          ✅ configured  (or ❌ not configured)
-Context7      ✅ no credentials needed
+Integration              Status
+──────────────────────   ──────
+PubMed                   ✅ configured  (or ❌ not configured)
+bioRxiv                  ✅ no credentials needed
+Miro                     ✅ configured  (or ❌ not configured)
+Context7                 ✅ no credentials needed
+Google Workspace CLI     ✅ installed  (or ❌ not installed)
+  └─ OAuth credentials   ✅ configured  (or ❌ not configured)
 ```
 
 ---
@@ -74,7 +78,98 @@ Ask: "Paste your Miro access token (or press Enter to skip):"
 
 ---
 
-## Step 4 — Save and confirm
+## Step 4 — Google Workspace CLI setup
+
+This step covers the `gws` CLI — a single tool for Drive, Gmail, Calendar, Sheets, Docs, and more. It is optional but enables the Google Calendar and Gmail MCP integrations in neuroflow.
+
+### 4a — Check if gws is installed
+
+Run `gws --version 2>/dev/null` or `which gws`. If the command is found, skip to Step 4b.
+
+**If not installed:**
+
+Tell the user:
+> **Google Workspace CLI (`gws`)** is not installed.
+>
+> **Prerequisites:** Node.js 18+ required. Run `node --version` to check — if missing, install from https://nodejs.org
+>
+> Install with:
+> ```bash
+> npm install -g @googleworkspace/cli
+> ```
+> Then run `/neuroflow:setup` again to configure credentials.
+
+Ask: "Install `gws` now? (y/N)"
+- If yes: run `npm install -g @googleworkspace/cli` and confirm success, then continue to 4b.
+- If no: note it was skipped, move to Step 5.
+
+### 4b — Check OAuth credentials
+
+Run `which gcloud 2>/dev/null` to check if the `gcloud` CLI is present.
+
+**If `gcloud` IS installed:** fully automated. Run:
+```bash
+gws auth setup --login
+```
+This creates the GCP project, enables APIs, creates an OAuth app, and opens the browser for login in one command. Skip the rest of this step.
+
+**If `gcloud` is NOT installed** (the common case): `gws auth setup` exits with `"gcloud CLI not found"`. The workaround is a one-time manual step in the browser — after that, `gws auth login` opens the browser automatically on every re-auth.
+
+Tell the user:
+> **One-time setup required in Google Cloud Console.** `gws auth setup` needs `gcloud` (not installed). Do this once:
+>
+> **Part A — Create OAuth credentials:**
+> 1. Opening https://console.cloud.google.com/apis/credentials in your browser now.
+> 2. Create a project (or select an existing one)
+> 3. Click **+ Create Credentials → OAuth client ID**
+> 4. Application type: **Desktop app** → name it anything → **Create**
+> 5. Click **Download JSON** → save the file to:
+>    - **Windows:** `C:\Users\<your-name>\.config\gws\client_secret.json`
+>    - **macOS/Linux:** `~/.config/gws/client_secret.json`
+> 6. Come back here and press Enter — `gws auth login` will open your browser to complete sign-in (Google may show an "unverified app" warning — click Advanced → Continue).
+>
+> **Part B — Enable the APIs** (required — `gws auth setup` would have done this automatically):
+> For each API you want to use, open its library URL and click **Enable**:
+> - Calendar: https://console.cloud.google.com/apis/library/calendar-json.googleapis.com
+> - Gmail: https://console.cloud.google.com/apis/library/gmail.googleapis.com
+> - Drive: https://console.cloud.google.com/apis/library/drive.googleapis.com
+> - Sheets: https://console.cloud.google.com/apis/library/sheets.googleapis.com
+> - Docs: https://console.cloud.google.com/apis/library/docs.googleapis.com
+> - Slides: https://console.cloud.google.com/apis/library/slides.googleapis.com
+> - Tasks: https://console.cloud.google.com/apis/library/tasks.googleapis.com
+>
+> Append `?project=<your-project-id>` to each URL to go directly to the right project.
+>
+> **Tip:** Install `gcloud` to skip all of this in future projects: https://cloud.google.com/sdk/docs/install
+
+Open the URL now: run `start https://console.cloud.google.com/apis/credentials` (Windows) or `open https://console.cloud.google.com/apis/credentials` (macOS/Linux).
+
+Wait for the user to confirm they have downloaded `client_secret.json`, then run:
+```bash
+gws auth login
+```
+This opens the browser for OAuth consent automatically. On success, `gws auth status` should show the authenticated account.
+
+**Alternative — env vars (no file download needed):** the user can paste the Client ID and Client Secret directly from the GCP Console instead of downloading the file:
+> From the GCP Console OAuth credential page, copy the **Client ID** and **Client Secret** values and set:
+> ```bash
+> export GOOGLE_WORKSPACE_CLI_CLIENT_ID="<client-id>"
+> export GOOGLE_WORKSPACE_CLI_CLIENT_SECRET="<client-secret>"
+> ```
+> Then run `gws auth login`.
+
+**If credentials are already configured** (client_secret.json exists at the platform path, or `GOOGLE_WORKSPACE_CLI_CLIENT_ID` env var is set):
+- Run `gws auth status 2>&1` to check. If authenticated, ask "Google Workspace is already authenticated. Re-authenticate? (y/N)". If no, skip to Step 5.
+
+**If credentials are not configured:**
+- Ask: "Which auth method? (1) I'll save client_secret.json  (2) Paste Client ID + Secret  (3) Skip"
+- **Option 1:** open GCP Console URL, wait for confirmation, run `gws auth login` (opens browser).
+- **Option 2:** ask for Client ID and Client Secret; store both; run `gws auth login` (opens browser).
+- **Option 3:** note it was skipped.
+
+---
+
+## Step 5 — Save and confirm
 
 **If any credentials were entered:**
 
@@ -88,6 +183,11 @@ Ask: "Paste your Miro access token (or press Enter to skip):"
   },
   "miro": {
     "MIRO_ACCESS_TOKEN": "eyJ..."
+  },
+  "google_workspace": {
+    "GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE": "/home/user/.config/gws/client_secret.json",
+    "GOOGLE_WORKSPACE_CLI_CLIENT_ID": "<optional — alternative to file>",
+    "GOOGLE_WORKSPACE_CLI_CLIENT_SECRET": "<optional — alternative to file>"
   }
 }
 ```
@@ -104,6 +204,10 @@ Ask: "Paste your Miro access token (or press Enter to skip):"
 > ```bash
 > export PUBMED_EMAIL="user@example.com"
 > export MIRO_ACCESS_TOKEN="eyJ..."
+> export GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE="$HOME/.config/gws/client_secret.json"
+# or, if using env vars instead of file:
+export GOOGLE_WORKSPACE_CLI_CLIENT_ID="<client-id>"
+export GOOGLE_WORKSPACE_CLI_CLIENT_SECRET="<client-secret>"
 > ```
 > Or add them to your shell profile (`~/.zshrc`, `~/.bashrc`) so they load automatically.
 
@@ -113,7 +217,7 @@ Tell the user: "No credentials saved. You can run `/neuroflow:setup` at any time
 
 ---
 
-## Step 5 — Suggest next step
+## Step 6 — Suggest next step
 
 - If the user came from `/neuroflow`, tell them to continue with the suggested phase command.
 - Otherwise, suggest: "Run `/neuroflow:ideation` to start exploring literature, or any other command to continue your project."

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,14 @@ title: Changelog
 
 ---
 
+## 0.2.5
+
+- **`/poster`** — generate a LaTeX conference poster from project memory; five templates (A0/A1 portrait, A0 landscape, 90×120 cm, 48×36 in); QR code via `qrcode` package; iterative `poster-critic` review loop (up to 3 cycles) before `.tex` is saved
+- **New `poster-critic` agent** — five-area poster auditor (content, layout, scientific communication, QR code, LaTeX correctness); returns `[STATUS: APPROVED]`/`[STATUS: REJECTED]` with specific fixes; never rewrites content
+- **New `neuroflow:phase-poster` skill** — full LaTeX template catalogue, template selection guide, content extraction from `.neuroflow/`, QR code blocks, compilation instructions
+
+---
+
 ## 0.2.4
 
 - **Sentinel Check 3b** — sentinel now validates that `.claude-plugin/marketplace.json` version matches `plugin.json`; marketplace version was silently stuck at `0.1.0`

--- a/docs/commands/poster.md
+++ b/docs/commands/poster.md
@@ -1,0 +1,113 @@
+---
+title: /poster
+---
+
+# `/neuroflow:poster`
+
+**Generate a LaTeX conference poster from project memory.**
+
+`/poster` builds a publication-ready academic conference poster as a `.tex` file from your `.neuroflow/` project memory. Choose a template size, optionally add a QR code, and Claude will extract your title, authors, methods, key results, and conclusions — then run the draft through an iterative `poster-critic` review loop before saving.
+
+---
+
+## When to use it
+
+- Before a conference (SfN, OHBM, Bernstein, COSYNE, NeurIPS…)
+- For a lab retreat or departmental poster session
+- When you want a print-ready poster tied directly to your project data
+
+---
+
+## What it does
+
+Claude asks:
+
+1. **Conference name** — used to infer the standard poster size if not specified
+2. **Template size** — five options (see below)
+3. **QR code URL** — preprint DOI, OSF page, GitHub repo, or skip
+4. **Authors and affiliations** — confirmed or updated from `project_config.md`
+5. **Which sections to include** — all five standard sections or a subset
+
+Then Claude reads the relevant `.neuroflow/` phase files, populates the template, and submits the draft to the `poster-critic` agent for iterative review (up to 3 cycles).
+
+---
+
+## Template sizes
+
+| Option | Size | Orientation | Typical use |
+|---|---|---|---|
+| A | A0 (841 × 1189 mm) | Portrait | Most European conferences; SfN, OHBM, Bernstein |
+| B | A0 (1189 × 841 mm) | Landscape | Wide-format boards; side-by-side figures |
+| C | A1 (594 × 841 mm) | Portrait | Lab retreats, seminars, smaller venues |
+| D | 90 × 120 cm | Portrait | Common European conference custom size |
+| E | 48 × 36 in | Landscape | US conferences (COSYNE, NeurIPS, SfN US booths) |
+
+All templates use the `tikzposter` LaTeX class with a consistent blue colour theme and support the `qrcode` package for QR code generation.
+
+---
+
+## QR code
+
+If you provide a URL, Claude inserts a `\qrcode{}` block in the poster footer. The `poster-critic` agent will flag a missing or placeholder QR URL if you requested one.
+
+Recommended targets:
+
+- bioRxiv preprint: `https://doi.org/10.1101/XXXX`
+- OSF preregistration URL
+- GitHub repository
+- Lab or personal page
+
+---
+
+## Iterative critic review
+
+The generated `.tex` source is reviewed by the `poster-critic` agent against a five-area rubric before the file is saved:
+
+1. **Content accuracy** — title, authors, objectives, N, methods, results with numerical values, references
+2. **Visual balance** — column proportions, section density, title prominence
+3. **Scientific communication** — claims stated with statistics, figure captions, appropriate jargon level
+4. **QR code** — present and non-placeholder (if requested)
+5. **LaTeX correctness** — column fractions ≤ 1.0, required packages, no unclosed environments
+
+The loop runs up to 3 iterations. Unresolved issues are logged to `.neuroflow/poster/critic-log.md`.
+
+---
+
+## Compilation
+
+After saving, compile with:
+
+```bash
+cd .neuroflow/poster
+pdflatex poster-YYYY-MM-DD.tex
+```
+
+Or with latexmk:
+
+```bash
+latexmk -pdf poster-YYYY-MM-DD.tex
+```
+
+**Required packages:** `tikzposter`, `qrcode`, `graphicx`, `booktabs`, `amsmath` — all in TeX Live ≥ 2020 and MiKTeX.
+
+**Figures:** Replace each `\includegraphics{figures/...}` stub with the actual figure file. Use `.pdf` or `.eps` for vector graphics; `.png`/`.jpg` for bitmaps.
+
+---
+
+## Output
+
+| Direction | Files |
+|---|---|
+| Reads | `.neuroflow/project_config.md`, `.neuroflow/flow.md`, `.neuroflow/ideation/flow.md`, `.neuroflow/data-analyze/flow.md`, `.neuroflow/paper/flow.md`, `.neuroflow/preregistration/flow.md` |
+| Writes | `.neuroflow/poster/poster-YYYY-MM-DD.tex`, `.neuroflow/poster/critic-log.md`, `.neuroflow/sessions/YYYY-MM-DD.md` |
+
+If a same-date `.tex` file exists, a version suffix is added (`-v2`, `-v3`, etc.).
+
+---
+
+## Related commands
+
+- [`/slideshow`](slideshow.md) — build a talk slide deck for the same conference
+- [`/paper`](paper.md) — write up the results as a manuscript
+- [`/write-report`](write-report.md) — generate a prose summary of the project
+- [`/output`](output.md) — package the poster file for sharing or archiving

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ hide:
 ---
 
 <div class="sa-bar">
-  <span class="sa-bar-label">🧠 self-assessment <span class="sa-bar-version">v0.2.4</span></span>
+  <span class="sa-bar-label">🧠 self-assessment <span class="sa-bar-version">v0.2.5</span></span>
   <div class="sa-items">
     <span class="sa-item" data-tip="Prediction error detected?">
       <span class="sa-q-short">Pred. error</span><span class="probe-badge probe-yes">YES</span>

--- a/docs/javascripts/mind.js
+++ b/docs/javascripts/mind.js
@@ -47,6 +47,7 @@
     { id: "cmd-flowie",          label: "/flowie",          type: "command", phase: "flowie",         tags: ["human","memory"],           desc: "Personal identity layer — link a private GitHub repo to store your research profile (stances, writing style, methodological preferences). Supports profile creation, sync, and cross-project linking.",     url: "commands/flowie/" },
     { id: "cmd-hive",            label: "/hive",            type: "command", phase: "hive",           tags: ["memory","human"],           desc: "Connect neuroflow to a shared team GitHub org repo for research direction coordination and explicit knowledge sharing. Never auto-shares personal project data.",                                         url: "commands/hive/" },
     { id: "cmd-slideshow",       label: "/slideshow",       type: "command", phase: "slideshow",      tags: ["writing","human"],          desc: "Build a presentation from selected project areas — pick phases, figures, and key findings, then get a structured slide deck ready to export.",                   url: "commands/slideshow/" },
+    { id: "cmd-poster",          label: "/poster",          type: "command", phase: "poster",         tags: ["writing","human"],          desc: "Generate a LaTeX conference poster from project memory — five templates (A0/A1, portrait/landscape, US size), QR code support, and iterative poster-critic review loop.",  url: "commands/poster/" },
 
     /* ── Skills ── */
     { id: "sk-core",          label: "neuroflow-core",         type: "skill", tags: ["memory"],              desc: "Core lifecycle rules — what every command must read, write, and follow across all phases.",                                           url: "skills/neuroflow-core/SKILL/" },
@@ -79,6 +80,7 @@
     { id: "sk-flowie",        label: "phase-flowie",           type: "skill", tags: ["human","memory"],     desc: "Personal identity layer guidance — how to read and use the flowie profile for personalization, write rules, GitHub sync, and profile-aware assistance across all phases.",                          url: "skills/phase-flowie/SKILL/" },
     { id: "sk-hive",          label: "phase-hive",             type: "skill", tags: ["memory","human"],     desc: "Team-level knowledge layer — connects a researcher's neuroflow project to a shared GitHub org repo for coordinating directions, sharing findings, and team-aware recommendations.",                 url: "skills/phase-hive/SKILL/" },
     { id: "sk-slideshow",     label: "phase-slideshow",        type: "skill", tags: ["writing"],            desc: "Presentation guidance — slide structure decisions, format selection, and audience calibration for building slide decks from project memory.",                                                        url: "skills/phase-slideshow/SKILL/" },
+    { id: "sk-poster",        label: "phase-poster",           type: "skill", tags: ["writing"],            desc: "LaTeX poster generation — five conference templates (A0/A1, portrait/landscape, US size), QR code blocks, content extraction from project memory, and compilation instructions.",                 url: "skills/phase-poster/SKILL/" },
     { id: "sk-notebooklm",   label: "notebooklm",             type: "skill", tags: ["literature","human"], desc: "Google NotebookLM integration — create notebooks, add sources, generate podcasts, quizzes, infographics, slide decks, and mind maps from research materials.",                                    url: "skills/notebooklm/SKILL/" },
     { id: "sk-pupil-labs",   label: "pupil-labs-neon",        type: "skill", tags: ["eeg","code"],         desc: "Pupil Labs Neon real-time eye-tracking — connect to Neon glasses and collect live gaze, video, and IMU streams via the Real-time API.",                                                               url: "skills/pupil-labs-neon-realtime/SKILL/" },
     { id: "sk-worker-critic",label: "worker-critic",          type: "skill", tags: ["code"],               desc: "Worker-critic agentic loop — orchestrator coordinates a worker and a critic across up to 3 revision cycles to produce a vetted output for any phase.",                                              url: "skills/worker-critic/SKILL/" },
@@ -106,7 +108,8 @@
     { id: "ag-paper-writer",  label: "paper-writer",    type: "agent", tags: ["writing"],            desc: "Manuscript writer — drafts neuroscience manuscript sections from upstream project memory inside a brutal write→critique loop with the paper-critic agent.",                                             url: "concepts/agents/" },
     { id: "ag-paper-critic",  label: "paper-critic",    type: "agent", tags: ["writing","stats"],    desc: "Hyper-critical manuscript reviewer — applies full six-area review-neuro methodology to every draft and returns APPROVED or REJECTED with zero tolerance for overclaims.",                               url: "concepts/agents/" },
     { id: "ag-lit-review",    label: "literature-review",type: "agent",tags: ["literature"],          desc: "Literature review specialist — runs 12 sequential analytical lenses on downloaded papers using the worker-critic loop to ensure rigour. Scoped to the ideation phase.",                              url: "concepts/agents/" },
-    { id: "ag-critic",        label: "critic",           type: "agent", tags: ["code"],               desc: "Critic agent — audits worker drafts against a provided rubric; returns APPROVED or REJECTED with specific actionable feedback; used by the orchestrator in the worker-critic loop.",                url: "concepts/agents/" }
+    { id: "ag-critic",        label: "critic",           type: "agent", tags: ["code"],               desc: "Critic agent — audits worker drafts against a provided rubric; returns APPROVED or REJECTED with specific actionable feedback; used by the orchestrator in the worker-critic loop.",                url: "concepts/agents/" },
+    { id: "ag-poster-critic", label: "poster-critic",    type: "agent", tags: ["writing"],            desc: "Conference poster critic — audits every LaTeX poster draft across five areas; returns APPROVED or REJECTED with specific, actionable feedback; operates inside the /poster worker-critic loop.",     url: "concepts/agents/" }
   ];
 
   var LINKS = [
@@ -121,6 +124,7 @@
     { source: "cmd-flowie",          target: "core", type: "rw" },
     { source: "cmd-hive",            target: "core", type: "rw" },
     { source: "cmd-slideshow",       target: "core", type: "r"  },
+    { source: "cmd-poster",          target: "core", type: "rw" },
     { source: "cmd-interview",       target: "core", type: "rw" },
     { source: "cmd-quiz",            target: "core", type: "r"  },
     { source: "cmd-fails",           target: "core", type: "rw" },
@@ -175,6 +179,7 @@
     { source: "sk-flowie",         target: "cmd-flowie",          type: "uses" },
     { source: "sk-hive",           target: "cmd-hive",            type: "uses" },
     { source: "sk-slideshow",      target: "cmd-slideshow",       type: "uses" },
+    { source: "sk-poster",         target: "cmd-poster",          type: "uses" },
 
     /* Commands → Agents (spawns) */
     { source: "cmd-ideation",        target: "ag-ideation",     type: "spawns" },
@@ -197,6 +202,7 @@
     { source: "cmd-flowie",          target: "ag-flowie",       type: "spawns" },
     { source: "cmd-paper",           target: "ag-paper-writer", type: "spawns" },
     { source: "cmd-paper",           target: "ag-paper-critic", type: "spawns" },
+    { source: "cmd-poster",          target: "ag-poster-critic",type: "spawns" },
     { source: "cmd-ideation",        target: "ag-lit-review",   type: "spawns" },
 
     /* Pipeline orchestrates many commands */
@@ -261,6 +267,7 @@
     "write-report":    318,
     "review":          332,
     "slideshow":       338,
+    "poster":          341,
     "output":          344,
     "utility":         350,
     "hive":            355,
@@ -304,7 +311,9 @@
     "ag-orchestrator":  "utility",
     "ag-paper-writer":  "paper",
     "ag-paper-critic":  "paper",
-    "ag-lit-review":    "ideation"
+    "ag-lit-review":    "ideation",
+    "sk-poster":        "poster",
+    "ag-poster-critic": "poster"
   };
 
   /* ── State ───────────────────────────────────────────────────────────────── */

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,7 +93,7 @@ markdown_extensions:
   - pymdownx.smartsymbols
 
 extra:
-  version: "0.2.4"
+  version: "0.2.5"
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/stanislavjiricek/neuroflow
@@ -150,6 +150,7 @@ nav:
           - "📍 phase": commands/phase.md
           - "🛡️ sentinel": commands/sentinel.md
           - "🎞️ slideshow": commands/slideshow.md
+          - "🖼️ poster": commands/poster.md
           - "🧩 quiz": commands/quiz.md
           - "💢 fails": commands/fails.md
           - "💭 idk": commands/idk.md
@@ -180,6 +181,7 @@ nav:
           - "phase-notes": skills/phase-notes/SKILL.md
           - "phase-write-report": skills/phase-write-report/SKILL.md
           - "phase-slideshow": skills/phase-slideshow/SKILL.md
+          - "phase-poster": skills/phase-poster/SKILL.md
           - "phase-brain-build": skills/phase-brain-build/SKILL.md
           - "phase-brain-optimize": skills/phase-brain-optimize/SKILL.md
           - "phase-brain-run": skills/phase-brain-run/SKILL.md
@@ -200,6 +202,7 @@ nav:
       - Overview: concepts/agents.md
       - "critic": agents/critic.md
       - "orchestrator": agents/orchestrator.md
+      - "poster-critic": agents/poster-critic.md
   - Integrations: integrations.md
   - Troubleshooting: troubleshooting.md
   - Changelog: changelog.md

--- a/skills/phase-poster/SKILL.md
+++ b/skills/phase-poster/SKILL.md
@@ -1,0 +1,507 @@
+---
+name: phase-poster
+description: Phase guidance for the neuroflow /poster command. LaTeX academic conference poster generation — template selection (A0/A1/A2, portrait/landscape, custom conference sizes), QR code integration, content extraction from project memory, and iterative poster-critic review loop.
+---
+
+# phase-poster
+
+The poster phase generates a publication-ready academic conference poster as a LaTeX `.tex` file, compiled to PDF. Content is extracted from `.neuroflow/` project memory. The poster goes through an iterative critic loop (up to 3 cycles) before final output.
+
+---
+
+## Approach
+
+1. Confirm conference name, target size, orientation, and QR code URL with the user before loading any files
+2. Read `.neuroflow/project_config.md` and relevant phase `flow.md` files to extract title, authors, affiliations, key findings, methods, and figures
+3. Select the appropriate LaTeX template (see below)
+4. Generate the full `.tex` source with a QR code block if a URL is provided
+5. Run the poster through the `poster-critic` agent for iterative review (worker-critic loop, max 3 cycles)
+6. Save approved `.tex` and compiled PDF instructions to `.neuroflow/poster/`
+
+---
+
+## Template catalogue
+
+### Template A — A0 Portrait (841 × 1189 mm) — Standard conference
+
+```latex
+% ── neuroflow poster template: A0 portrait ───────────────────────────────
+\documentclass[25pt, a0paper, portrait, blockverticalspace=15mm]{tikzposter}
+
+\usepackage[utf8]{inputenc}
+\usepackage{amsmath, amssymb}
+\usepackage{graphicx}
+\usepackage{booktabs}
+\usepackage{multicol}
+\usepackage{qrcode}          % QR code package
+\usepackage{hyperref}
+
+% ── Colour theme ─────────────────────────────────────────────────────────
+\definecolor{nfBlue}{RGB}{30, 90, 160}
+\definecolor{nfLightBlue}{RGB}{210, 230, 255}
+\definecolor{nfAccent}{RGB}{220, 80, 30}
+
+\definetitlestyle{nfTitle}{
+  width=\textwidth, roundedcorners=10, linewidth=2pt,
+  innersep=10pt, titletotopverticalspace=0pt,
+  titletoblockverticalspace=20mm
+}{
+  \begin{scope}[line width=\titlelinewidth, rounded corners=\titleroundedcorners]
+    \fill[color=nfBlue] (\titleposleft,\titleposbottom) rectangle (\titleposright,\titlepostop);
+  \end{scope}
+}
+
+\definelayouttheme{nfTheme}{
+  titlestyle=nfTitle, headerheight=0.12\textheight,
+  blockstyle=Slide, backgroundstyle=Empty
+}
+\usetheme{nfTheme}
+\colorlet{titlebgcolor}{nfBlue}
+\colorlet{titlefgcolor}{white}
+\colorlet{blocktitlebgcolor}{nfBlue}
+\colorlet{blocktitlefgcolor}{white}
+\colorlet{blockbodybgcolor}{nfLightBlue}
+
+% ── Title block ───────────────────────────────────────────────────────────
+\title{\textbf{POSTER TITLE HERE}}
+\author{Author One\textsuperscript{1}, Author Two\textsuperscript{2}, Author Three\textsuperscript{1}}
+\institute{\textsuperscript{1}Institution One, City, Country \quad
+           \textsuperscript{2}Institution Two, City, Country}
+\date{Conference Name, Month Year}
+
+\begin{document}
+\maketitle
+
+% ── Three-column layout ───────────────────────────────────────────────────
+\begin{columns}
+
+  % ── Column 1 ─────────────────────────────────────────────────────────
+  \column{0.33}
+
+  \block{Introduction}{
+    Provide the scientific background and motivation.
+    State the gap your study addresses.
+    Keep to 3–4 short paragraphs.
+  }
+
+  \block{Objectives}{
+    \begin{itemize}
+      \item Primary aim of the study
+      \item Secondary aim / hypothesis 1
+      \item Hypothesis 2 (if applicable)
+    \end{itemize}
+  }
+
+  \block{Methods}{
+    \textbf{Participants:} N = X (age range, mean ± SD; X female).\\[0.5em]
+    \textbf{Design:} Brief paradigm description.\\[0.5em]
+    \textbf{Recording:} Modality, equipment, sampling rate.\\[0.5em]
+    \textbf{Analysis:} Key analysis steps and statistical approach.
+
+    \begin{center}
+      \includegraphics[width=0.9\linewidth]{figures/paradigm.pdf}
+      \par\small Figure 1. Experimental paradigm.
+    \end{center}
+  }
+
+  % ── Column 2 ─────────────────────────────────────────────────────────
+  \column{0.34}
+
+  \block{Results}{
+    \textbf{Finding 1:} One-sentence statement of the result.\\[0.5em]
+    \begin{center}
+      \includegraphics[width=0.9\linewidth]{figures/result1.pdf}
+      \par\small Figure 2. Key result with caption.
+    \end{center}
+
+    \vspace{0.5em}
+    \textbf{Finding 2:} One-sentence statement of the result.
+    \begin{center}
+      \includegraphics[width=0.9\linewidth]{figures/result2.pdf}
+      \par\small Figure 3. Secondary result with caption.
+    \end{center}
+  }
+
+  % ── Column 3 ─────────────────────────────────────────────────────────
+  \column{0.33}
+
+  \block{Discussion}{
+    Interpret the key findings.
+    Link back to the objectives.
+    Address limitations (one paragraph).
+  }
+
+  \block{Conclusions}{
+    \begin{itemize}
+      \item \textbf{Main takeaway} — one sentence
+      \item \textbf{Implication} — one sentence
+      \item \textbf{Future direction} — one sentence
+    \end{itemize}
+  }
+
+  \block{References}{
+    \small
+    \begin{enumerate}
+      \item[{[1]}] Author et al. (Year). Title. \textit{Journal}, \textbf{Vol}, pages.
+      \item[{[2]}] Author et al. (Year). Title. \textit{Journal}, \textbf{Vol}, pages.
+    \end{enumerate}
+  }
+
+  \block{}{
+    \begin{minipage}[t]{0.65\linewidth}
+      \textbf{Acknowledgements:} Funding bodies, ethics committees, participants.\\[0.5em]
+      \textbf{Contact:} \texttt{corresponding.author@institution.edu}
+    \end{minipage}%
+    \hfill
+    \begin{minipage}[t]{0.30\linewidth}
+      \centering
+      % ── QR code block ─────────────────────────────────────────────────
+      \qrcode[height=4cm]{https://doi.org/10.XXXX/XXXXX}\\[0.3em]
+      \small Scan for preprint / data
+    \end{minipage}
+  }
+
+\end{columns}
+\end{document}
+```
+
+---
+
+### Template B — A0 Landscape (1189 × 841 mm) — Four-column wide format
+
+```latex
+% ── neuroflow poster template: A0 landscape ──────────────────────────────
+\documentclass[25pt, a0paper, landscape, blockverticalspace=15mm]{tikzposter}
+
+\usepackage[utf8]{inputenc}
+\usepackage{amsmath, amssymb}
+\usepackage{graphicx}
+\usepackage{booktabs}
+\usepackage{qrcode}
+\usepackage{hyperref}
+
+\definecolor{nfBlue}{RGB}{30, 90, 160}
+\definecolor{nfLightBlue}{RGB}{210, 230, 255}
+
+\colorlet{titlebgcolor}{nfBlue}
+\colorlet{titlefgcolor}{white}
+\colorlet{blocktitlebgcolor}{nfBlue}
+\colorlet{blocktitlefgcolor}{white}
+\colorlet{blockbodybgcolor}{nfLightBlue}
+\usetheme{Slide}
+
+\title{\textbf{POSTER TITLE HERE}}
+\author{Author One\textsuperscript{1}, Author Two\textsuperscript{2}}
+\institute{\textsuperscript{1}Institution One \quad \textsuperscript{2}Institution Two}
+\date{Conference Name, Month Year}
+
+\begin{document}
+\maketitle
+
+\begin{columns}
+  \column{0.25}
+  \block{Introduction}{ Background and gap. }
+  \block{Objectives}{ \begin{itemize}\item Aim 1 \item Aim 2 \end{itemize} }
+
+  \column{0.25}
+  \block{Methods}{
+    \textbf{Participants:} N = X.\\
+    \textbf{Design:} Paradigm.\\
+    \textbf{Analysis:} Pipeline.
+    \begin{center}\includegraphics[width=0.85\linewidth]{figures/paradigm.pdf}\end{center}
+  }
+
+  \column{0.25}
+  \block{Results}{
+    \textbf{Key finding.}
+    \begin{center}\includegraphics[width=0.85\linewidth]{figures/result1.pdf}\end{center}
+    \begin{center}\includegraphics[width=0.85\linewidth]{figures/result2.pdf}\end{center}
+  }
+
+  \column{0.25}
+  \block{Discussion \& Conclusions}{
+    Interpretation and implications.
+    \begin{itemize}
+      \item Takeaway 1
+      \item Takeaway 2
+      \item Future work
+    \end{itemize}
+  }
+  \block{}{
+    \begin{minipage}[t]{0.6\linewidth}
+      \small \textbf{Contact:} \texttt{email@institution.edu}\\
+      \textbf{Funding:} Grant agency, grant number.
+    \end{minipage}\hfill
+    \begin{minipage}[t]{0.35\linewidth}
+      \centering
+      \qrcode[height=3.5cm]{https://doi.org/10.XXXX/XXXXX}\\
+      \small Preprint / data
+    \end{minipage}
+  }
+\end{columns}
+\end{document}
+```
+
+---
+
+### Template C — A1 Portrait (594 × 841 mm) — Smaller venue / seminar
+
+```latex
+% ── neuroflow poster template: A1 portrait ───────────────────────────────
+\documentclass[20pt, a1paper, portrait, blockverticalspace=10mm]{tikzposter}
+
+\usepackage[utf8]{inputenc}
+\usepackage{amsmath, amssymb}
+\usepackage{graphicx}
+\usepackage{qrcode}
+\usepackage{hyperref}
+
+\definecolor{nfBlue}{RGB}{30, 90, 160}
+\definecolor{nfLightBlue}{RGB}{210, 230, 255}
+\colorlet{titlebgcolor}{nfBlue}
+\colorlet{titlefgcolor}{white}
+\colorlet{blocktitlebgcolor}{nfBlue}
+\colorlet{blocktitlefgcolor}{white}
+\colorlet{blockbodybgcolor}{nfLightBlue}
+\usetheme{Slide}
+
+\title{\textbf{POSTER TITLE}}
+\author{Author One, Author Two}
+\institute{Institution, City, Country}
+\date{Conference Name, Month Year}
+
+\begin{document}
+\maketitle
+
+\begin{columns}
+  \column{0.5}
+  \block{Introduction}{ Background. Gap. }
+  \block{Methods}{ Participants, design, analysis. }
+  \block{Objectives}{ \begin{itemize}\item Aim 1 \item Aim 2\end{itemize} }
+
+  \column{0.5}
+  \block{Results}{
+    \begin{center}\includegraphics[width=0.9\linewidth]{figures/result1.pdf}\end{center}
+  }
+  \block{Conclusions}{
+    \begin{itemize}\item Main finding \item Implication\end{itemize}
+  }
+  \block{}{
+    \centering
+    \qrcode[height=3cm]{https://doi.org/10.XXXX/XXXXX}\\
+    \small \textbf{Contact:} \texttt{email@inst.edu}
+  }
+\end{columns}
+\end{document}
+```
+
+---
+
+### Template D — Custom conference size (90 × 120 cm) — Portrait
+
+```latex
+% ── neuroflow poster template: 90×120 cm portrait ────────────────────────
+\documentclass[25pt, blockverticalspace=15mm]{tikzposter}
+
+\usepackage[utf8]{inputenc}
+\usepackage{amsmath, amssymb}
+\usepackage{graphicx}
+\usepackage{qrcode}
+\usepackage{geometry}
+\geometry{paperwidth=90cm, paperheight=120cm, margin=2cm}
+
+\definecolor{nfBlue}{RGB}{30, 90, 160}
+\definecolor{nfLightBlue}{RGB}{210, 230, 255}
+\colorlet{titlebgcolor}{nfBlue}
+\colorlet{titlefgcolor}{white}
+\colorlet{blocktitlebgcolor}{nfBlue}
+\colorlet{blocktitlefgcolor}{white}
+\colorlet{blockbodybgcolor}{nfLightBlue}
+\usetheme{Slide}
+
+\title{\textbf{POSTER TITLE}}
+\author{Authors}
+\institute{Affiliations}
+\date{Conference, Date}
+
+\begin{document}
+\maketitle
+\begin{columns}
+  \column{0.33}
+  \block{Introduction}{ Background. Gap. Motivation. }
+  \block{Methods}{ Participants, design, recording, analysis. }
+
+  \column{0.34}
+  \block{Results}{
+    \begin{center}\includegraphics[width=0.9\linewidth]{figures/result1.pdf}\end{center}
+    \begin{center}\includegraphics[width=0.9\linewidth]{figures/result2.pdf}\end{center}
+  }
+
+  \column{0.33}
+  \block{Discussion}{ Interpretation. Limitations. }
+  \block{Conclusions}{
+    \begin{itemize}\item Takeaway 1 \item Takeaway 2\end{itemize}
+  }
+  \block{}{
+    \begin{minipage}[t]{0.6\linewidth}
+      \small References and acknowledgements.
+    \end{minipage}\hfill
+    \begin{minipage}[t]{0.35\linewidth}
+      \centering
+      \qrcode[height=4cm]{https://doi.org/10.XXXX/XXXXX}\\
+      \small Scan for more
+    \end{minipage}
+  }
+\end{columns}
+\end{document}
+```
+
+---
+
+### Template E — 48 × 36 inches Landscape (US conference format)
+
+```latex
+% ── neuroflow poster template: 48×36 in landscape (US) ───────────────────
+\documentclass[25pt, blockverticalspace=15mm]{tikzposter}
+
+\usepackage[utf8]{inputenc}
+\usepackage{amsmath, amssymb}
+\usepackage{graphicx}
+\usepackage{qrcode}
+\usepackage{geometry}
+\geometry{paperwidth=48in, paperheight=36in, margin=1.5in}
+
+\definecolor{nfBlue}{RGB}{30, 90, 160}
+\definecolor{nfLightBlue}{RGB}{210, 230, 255}
+\colorlet{titlebgcolor}{nfBlue}
+\colorlet{titlefgcolor}{white}
+\colorlet{blocktitlebgcolor}{nfBlue}
+\colorlet{blocktitlefgcolor}{white}
+\colorlet{blockbodybgcolor}{nfLightBlue}
+\usetheme{Slide}
+
+\title{\textbf{POSTER TITLE}}
+\author{Authors}
+\institute{Affiliations}
+\date{Conference, Date}
+
+\begin{document}
+\maketitle
+\begin{columns}
+  \column{0.25}
+  \block{Introduction}{ Background. Gap. }
+  \block{Objectives}{ \begin{itemize}\item Aim 1 \item Aim 2\end{itemize} }
+
+  \column{0.25}
+  \block{Methods}{ Participants, design, analysis pipeline. }
+
+  \column{0.25}
+  \block{Results}{
+    \begin{center}\includegraphics[width=0.9\linewidth]{figures/result1.pdf}\end{center}
+    \begin{center}\includegraphics[width=0.9\linewidth]{figures/result2.pdf}\end{center}
+  }
+
+  \column{0.25}
+  \block{Conclusions}{ Main takeaways. }
+  \block{}{
+    \centering
+    \qrcode[height=5cm]{https://doi.org/10.XXXX/XXXXX}\\[0.3em]
+    \small Scan for paper / data\\
+    \texttt{email@institution.edu}
+  }
+\end{columns}
+\end{document}
+```
+
+---
+
+## Template selection guide
+
+| Size | Orientation | Use when |
+|---|---|---|
+| A0 (841×1189 mm) | Portrait | Most European conferences; SfN, Bernstein, OHBM |
+| A0 (1189×841 mm) | Landscape | Wide-format boards; when you have many side-by-side figures |
+| A1 (594×841 mm) | Portrait | Lab retreats, seminars, smaller venues |
+| 90×120 cm | Portrait | Common European conference custom size |
+| 48×36 in | Landscape | US conferences (NeurIPS, COSYNE, SfN US booths) |
+
+When the user does not specify a size, ask. Default to A0 Portrait if they are unsure.
+
+---
+
+## QR code integration
+
+The `qrcode` LaTeX package is used for QR code generation. Install via TeX Live / MiKTeX:
+
+```
+tlmgr install qrcode
+```
+
+Usage in templates:
+
+```latex
+\qrcode[height=4cm]{https://your-url-here.com}
+```
+
+Recommended QR code targets:
+- OSF preregistration URL
+- bioRxiv preprint DOI (`https://doi.org/10.1101/XXXX.XX.XX.XXXXXXXX`)
+- GitHub repository URL
+- Personal lab page
+
+If the user has not provided a URL, ask. If they want to skip the QR code, remove the `\qrcode` block from the footer.
+
+---
+
+## Compilation
+
+Compile with `pdflatex` (recommended for tikzposter):
+
+```bash
+pdflatex poster.tex
+```
+
+Or with `latexmk` for automatic dependency resolution:
+
+```bash
+latexmk -pdf poster.tex
+```
+
+**Dependencies:** `tikzposter`, `qrcode`, `graphicx`, `booktabs`, `amsmath`. All available in TeX Live ≥ 2020 and MiKTeX.
+
+**Figure formats:** Use `.pdf` or `.eps` for vector figures, `.png`/`.jpg` for bitmaps. Avoid `.svg` directly (convert to `.pdf` first via Inkscape: `inkscape figure.svg --export-pdf=figure.pdf`).
+
+---
+
+## Content extraction from `.neuroflow/`
+
+When populating poster fields, read in this order:
+
+1. `.neuroflow/project_config.md` — project title, PI, affiliation, modality, target journal
+2. `.neuroflow/ideation/` — research question, hypotheses, key references
+3. `.neuroflow/data-analyze/` or latest analysis `flow.md` — key results, effect sizes, figure paths
+4. `.neuroflow/preregistration/` — objectives and analysis plan (if available)
+5. `.neuroflow/paper/` — if a draft exists, extract the abstract and conclusions
+
+If figures are referenced in flow.md files, list them for the user — do not attempt to embed binary image files; output their paths as `\includegraphics` stubs so the user can place the actual files.
+
+---
+
+## Output paths
+
+Save poster files to `.neuroflow/poster/`:
+
+```
+.neuroflow/poster/
+├── poster-YYYY-MM-DD.tex          ← LaTeX source
+├── figures/                       ← symlinks or stubs for figures
+└── critic-log.md                  ← iterative review log
+```
+
+If a same-date `.tex` file exists, append `-v2`, `-v3`, etc.
+
+---
+
+## Slash command
+
+`/neuroflow:poster` — runs this workflow as a slash command.

--- a/skills/worker-critic/SKILL.md
+++ b/skills/worker-critic/SKILL.md
@@ -169,6 +169,7 @@ Any phase command or agent can activate the worker-critic loop by invoking the `
 | notes | `notes` |
 | write-report | `write-report` |
 | slideshow | `write-report` |
+| poster | `/poster` command (command acts as worker; `poster-critic` is the critic) |
 | brain-build | `brain-build` |
 | brain-optimize | `brain-optimize` |
 | brain-run | `brain-run` |


### PR DESCRIPTION
…ck 3b

- Add /poster command: generates LaTeX conference poster from .neuroflow/ project memory; five templates (A0/A1 portrait, A0 landscape, 90×120cm, 48×36in US); QR code via \qrcode{} package; saves to .neuroflow/poster/
- Add poster-critic agent: five-area iterative critic (content accuracy, visual balance, scientific communication, QR code, LaTeX correctness); returns [STATUS: APPROVED]/[STATUS: REJECTED] with specific fixes; max 3 cycles
- Add neuroflow:phase-poster skill: full LaTeX template source for all five sizes, template selection guide, content extraction logic, compilation docs
- Update /setup: battle-tested Google Workspace CLI (gws) setup instructions; dynamic gcloud/node detection; manual OAuth path with Part A (credentials) and Part B (API enabling); unverified app warning; step numbering fixed
- Add sentinel Check 3b: verify docs/index.md sa-bar-version matches plugin.json on every run — self-assessment bar most commonly missed item
- Bump version 0.2.4 → 0.2.5; update README, changelog, mkdocs.yml, mind.js (poster phase at 341°), worker-critic phase mapping