### PR TITLE
feat: notes→flowie sync and daily wellbeing tracking (0.2.12)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "neuroflow",
       "source": "./",
       "description": "End-to-end research workflow plugin for neuroscience teams — from hypothesis to publication. Supports EEG, iEEG, fMRI, eye tracking, ECG, and multimodal recordings.",
-      "version": "0.2.11",
+      "version": "0.2.12",
       "author": {
         "name": "Stanislav Jiricek"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neuroflow",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "End-to-end research workflow plugin for neuroscience teams — from hypothesis to publication. Supports EEG, iEEG, fMRI, eye tracking, ECG, and other neuroscience modalities.",
   "author": {
     "name": "Stanislav Jiricek"

--- a/.neuroflow/project_config.md
+++ b/.neuroflow/project_config.md
@@ -1,7 +1,7 @@
 # neuroflow — project config
 
 **Project:** neuroflow Claude Code plugin
-**Plugin version:** 0.2.10
+**Plugin version:** 0.2.12
 **Phase:** active development
 **Repo:** https://github.com/stanislavjiricek/neuroflow
 

--- a/.neuroflow/sentinel-dev.md
+++ b/.neuroflow/sentinel-dev.md
@@ -1,131 +1,51 @@
-Last run: 2026-05-27
+Last run: 2026-04-02
 
 ## Issues found
 
 ---
 
-### 🔴 ISSUE 1 — Check 3b: Self-assessment bar version not updated (BLOCKING)
+### ISSUE 1 — Check 9d: Dead nav link — `docs/skills/setup/SKILL.md` missing (BLOCKING)
 
-`docs/index.md` contains `<span class="sa-bar-version">v0.2.8</span>` but `plugin.json` version is `0.2.10`.
-The sa-bar-version was NOT updated during the 0.2.10 bump. All other version markers are consistent:
-- `plugin.json`: `0.2.10` ✅
-- `README.md`: `## What's new in 0.2.10` ✅
-- `mkdocs.yml` `extra.version`: `"0.2.10"` ✅
-- `docs/index.md` `sa-bar-version`: **`v0.2.8`** ❌
+`mkdocs.yml` nav references `skills/setup/SKILL.md` (resolves to `docs/skills/setup/SKILL.md`) but this directory and file do not exist under `docs/`.
 
-**Fix:** Update `docs/index.md` — change `<span class="sa-bar-version">v0.2.8</span>` → `<span class="sa-bar-version">v0.2.10</span>`.
+All 35 other skill folders have a corresponding `docs/skills/<name>/` directory. Only `setup` is absent. The source `skills/setup/SKILL.md` exists in the plugin root.
 
----
-
-### 🔴 ISSUE 2 — Check 9d: Dead nav link — `docs/skills/setup/SKILL.md` missing (BLOCKING)
-
-`mkdocs.yml` nav references `skills/setup/SKILL.md` (resolves to `docs/skills/setup/SKILL.md`) but this file does not exist.
-The `docs/skills/setup/` directory was never created for the new `setup` skill.
-
-All other skills have their `docs/skills/<name>/SKILL.md` copy under `docs/`. Only `setup` is absent.
-`skills/setup/SKILL.md` (the source) exists in the repo root ✅ — the docs copy is missing.
-
-**Fix:** Create `docs/skills/setup/SKILL.md` (copy or symlink from `skills/setup/SKILL.md`), matching the pattern used for all other skills.
-
----
-
-### 🟡 ISSUE 3 — Check 8: hooks.json vs README Hooks table mismatch
-
-The README `## Hooks` section documents these two hooks:
-1. **ruff formatter** — `PostToolUse` Edit/Write — auto-formats `.py` files ✅ (exists in hooks.json)
-2. **session logger** — `PostToolUse` Write/Edit/Bash — appends to `.neuroflow/sessions/` ❌ **does NOT exist in hooks.json**
-
-`hooks.json` has these two hooks (both on `Edit|Write`):
-1. **ruff format** — `ruff format "$f" >/dev/null 2>&1; true` ✅ (documented in README)
-2. **flowie git-sync** — auto-commits and pushes `.neuroflow/flowie/` on file writes ❌ **NOT documented in README**
-
-The README still references the old "session logger" hook (removed in an earlier session). The new flowie git-sync hook added this session is absent from the README.
-
-**Fix:** Update README `## Hooks` table — remove the "session logger" row, add a row for the flowie git-sync hook.
-
----
-
-### 🟡 ISSUE 4 — Check 9c: `flowie` agent docs page not in mkdocs.yml nav
-
-`docs/agents/flowie.md` exists but is NOT listed in the `mkdocs.yml` Agents nav section.
-The nav currently lists only `critic`, `orchestrator`, and `poster-critic` under Agents.
-
-Note: most agent doc pages also lack nav entries (existing design — 21 of 24 are unlisted). This is an established pattern. However, since `flowie` was just added in this session and `docs/agents/flowie.md` was explicitly created, it should be evaluated whether it belongs in the nav alongside critic/orchestrator/poster-critic.
-
-**Fix (optional):** Add `"flowie": agents/flowie.md` to the Agents nav in `mkdocs.yml`, or acknowledge the existing pattern and leave it unlisted.
-
----
-
-### 🔴 ISSUE 5 — Check 12: Stale `.neuroflow/.flowie/` paths in docs/ copies (BLOCKING)
-
-The actual source files are clean:
-- `skills/phase-flowie/SKILL.md` — no stale paths ✅
-- `agents/flowie.md` — no stale paths ✅
-
-But the docs/ mirror copies are **out of date**:
-
-**`docs/agents/flowie.md`:**
-- Line 16: uses `.neuroflow/.flowie/profile.md` (old path — should be `.neuroflow/flowie/profile.md`)
-- Line 50: uses `.neuroflow/.flowie/` (old path — should be `.neuroflow/flowie/`)
-
-**`docs/skills/phase-flowie/SKILL.md`:**
-- Lines 3, 12, 62, 64, 69, 70, 88: `.neuroflow/.flowie/` → should be `.neuroflow/flowie/`
-- Line 24: `flowie_profile` → should be `flowie_project:`
-
-These docs copies appear to be the pre-migration version. The source files were updated but the docs/ copies were not.
-
-**Fix:** Sync `docs/agents/flowie.md` and `docs/skills/phase-flowie/SKILL.md` from their source counterparts, or apply targeted find-replace:
-- `.neuroflow/.flowie/` → `.neuroflow/flowie/`
-- `flowie_profile` → `flowie_project:` (line 24 of docs/skills/phase-flowie/SKILL.md)
-
----
-
-### 🔵 ISSUE 6 — Check 5: Naming overlap — `setup` is both a skill and a command (NOTE)
-
-`skills/setup/` and `commands/setup.md` share the identical bare name `setup`.
-Unlike all other phase skills which use the `phase-X` naming convention (e.g. `phase-ideation` vs `ideation`), the new `setup` skill uses the same name as its command with no prefix.
-
-This is the only exact naming overlap in the entire plugin. It is very likely intentional (the skill backs the command directly), but deviates from the established `phase-X` prefix convention for phase-paired skills.
-
-**No immediate fix required.** Flagged for awareness. If a naming convention policy update is desired, options are: rename skill to `phase-setup` or document the pattern as an explicit exception.
-
----
-
-### 🔵 ISSUE 7 — Check 4: Placeholder refs in neuroflow-develop/SKILL.md (NOTE — false positives)
-
-`skills/neuroflow-develop/SKILL.md` lines 83, 104, and 191 contain `neuroflow:my-skill`, `neuroflow:my-command`, and `neuroflow:skill-name`. These are **intentional developer-guide template examples** showing the invocation syntax, not real skill/command references. No fix required.
-
-All other flagged "broken skill refs" (e.g. `neuroflow:brain-build` in `phase-brain-build/SKILL.md`) are false positives — the regex matched `neuroflow:brain-build` *within* the slash command string `/neuroflow:brain-build`, which is a valid command invocation. No broken references found.
-
----
-
-### 🔵 ISSUE 8 — Check 10: Email-like strings in phase-poster SKILL.md (needs human review)
-
-`skills/phase-poster/SKILL.md` and its docs copy `docs/skills/phase-poster/SKILL.md` contain the following at these lines:
-- Line 153: `c***@institution.edu`
-- Line 232: `e***@institution.edu`
-- Line 292: `e***@inst.edu`
-- Line 410: `e***@institution.edu`
-
-These appear to be **LaTeX poster template examples** (placeholder author email fields inside `\author{}` blocks). The domain `institution.edu` is synthetic. These are very likely intentional — but `institution.edu` and `inst.edu` are not in the skip-list of synthetic domains.
-
-**[needs human review]** — Confirm these are LaTeX template examples with no real personal data, then optionally add `institution.edu` and `inst.edu` to the sensitive-scan skip list.
+**Fix:** Create `docs/skills/setup/SKILL.md` matching the pattern used for all other skills.
 
 ---
 
 ## Checks that passed
 
-- **Check 1 — Folder/frontmatter names:** All 36 skill folders, 24 agent files, and 33 command files match their `name:` frontmatter fields exactly. ✅
-- **Check 2 — README tables:** All command, skill, and agent files have rows in their respective README tables. All table links resolve to existing files. New `setup` command ✅, `setup` skill ✅, `flowie` agent ✅ all have rows. `neuroflow-developer` correctly points to `.github/agents/neuroflow-developer.md`. ✅
-- **Check 3 — Version sync (partial):** `plugin.json`, `README.md`, and `mkdocs.yml` all agree on `0.2.10`. ✅ (sa-bar-version fails — see Issue 1.)
-- **Check 6 — Command frontmatter completeness:** All 33 command files have all five required fields (`name`, `description`, `phase`, `reads`, `writes`). ✅
-- **Check 7 — .neuroflow subfolder purity:** `.neuroflow/` contains only `reasoning/` as a subfolder. No skill-named subfolders. ✅
-- **Check 8 (partial) — hooks.json structure:** Valid JSON. Both hooks have `matcher` and `hooks` items with `type` and `command`. Error suppression present in both (hook 1: `>/dev/null 2>&1` + `; true`; hook 2: `>/dev/null 2>&1` + `; true`). ✅ (README documentation mismatch — see Issue 3.)
-- **Check 9a — mkdocs.yml version:** `extra.version: "0.2.10"` matches `plugin.json`. ✅
-- **Check 9b — Command docs completeness:** All 33 command files have `docs/commands/<name>.md` and all appear in `mkdocs.yml` nav. `setup` command: `docs/commands/setup.md` exists ✅ and `"⚙️ setup": commands/setup.md` is in nav ✅.
-- **Check 9c — Skill docs completeness (partial):** All 36 skill folders appear in `mkdocs.yml` nav. `setup` skill is in nav. ✅ (docs file missing — see Issue 2.)
-- **Check 11 — mind.js sync:** All three new items are present in `docs/javascripts/mind.js`. `setup` skill: `{ id: "sk-setup", label: "setup", type: "skill", ... }` ✅. `setup` command: `{ id: "cmd-setup", label: "/setup", type: "command", ... }` ✅. `flowie` agent: `{ id: "ag-flowie", label: "flowie", type: "agent", ... }` ✅.
-- **Check 12 (source files) — Flowie path hygiene:** Source files `skills/phase-flowie/SKILL.md` and `agents/flowie.md` contain no stale `.neuroflow/.flowie/` paths. ✅ (docs/ copies are stale — see Issue 5.)
+- **Check 1 — Folder/frontmatter names:** All 36 skill folders, 24 agent files, and 33 command files match their `name:` frontmatter fields exactly. PASS
+- **Check 2 — README tables:** All commands, skills, and agents have rows in their respective README tables. All table links resolve to existing files. PASS
+- **Check 3 — Version sync:** All four version markers agree on `0.2.12`.
+  - `plugin.json`: `0.2.12` PASS
+  - `marketplace.json`: `0.2.12` PASS
+  - `README.md` — `## What's new in 0.2.12` heading present PASS
+  - `mkdocs.yml` `extra.version`: `"0.2.12"` PASS
+  - `docs/index.md` `sa-bar-version`: `v0.2.12` PASS
+  - `.neuroflow/project_config.md` `Plugin version`: `0.2.12` PASS
+- **Check 3b — Self-assessment bar sync:** `sa-bar-version` reads `v0.2.12`, matches `plugin.json`. PASS
+- **Check 4 — Dead references in modified files:**
+  - `commands/notes.md` — all `neuroflow:phase-notes` skill ref resolves; no broken refs. PASS
+  - `commands/flowie.md` — all `neuroflow:phase-flowie` skill ref resolves; `flowie_profile:` mention is documentation text (describing the old field to replace), not a live reference. PASS
+  - `skills/phase-notes/SKILL.md` — `neuroflow:neuroflow-core` resolves; `neuroflow:notes` appears only in the slash command string `/neuroflow:notes` (valid invocation form, not a skill ref). PASS
+  - `skills/phase-flowie/SKILL.md` — `neuroflow:neuroflow-core` resolves; `neuroflow:flowie` appears only in `/neuroflow:flowie` (valid command invocation). PASS
+- **Check 5 — Naming overlaps:** `setup` exists as both `skills/setup/` and `commands/setup.md`. This overlap pre-dates 0.2.12 and is unchanged. No new overlaps introduced. PASS (pre-existing known deviation)
+- **Check 6 — Command frontmatter completeness:** All 33 command files contain all five required fields (`name`, `description`, `phase`, `reads`, `writes`). PASS
+- **Check 7 — .neuroflow subfolder purity:** `.neuroflow/` contains only `reasoning/` as a subfolder. No skill-named subfolders present. PASS
+- **Check 8 — hooks.json audit:** Valid JSON. Both hook entries (`Edit|Write` matcher) have `type` and `command`. Error suppression verified:
+  - Hook 1 (ruff formatter): `>/dev/null 2>&1` and `; true` both present. PASS
+  - Hook 2 (flowie git-sync): `>/dev/null 2>&1` and `|| true` both present. PASS
+  - README Hooks table documents both `ruff formatter` and `flowie git-sync` — matches `hooks.json` entries. PASS
+- **Check 9a — mkdocs.yml version:** `extra.version: "0.2.12"` matches `plugin.json`. PASS
+- **Check 9b — Command docs completeness:** All 33 command files have `docs/commands/<name>.md` and all appear in `mkdocs.yml` nav. PASS
+- **Check 9c — Skill docs completeness (nav):** All 36 skill folders appear in `mkdocs.yml` nav. PARTIAL — `setup` skill is listed in nav but `docs/skills/setup/SKILL.md` is missing (see Issue 1).
+- **Check 9d — No dead nav links:** One dead link found — see Issue 1 above. All other nav entries resolve to existing files. PARTIAL
+- **Check 10 — Personal sensitive information:** No email addresses, passwords, secrets, private keys, or real personal names found in commands, agents, skills, docs, hooks, or README. PASS
+- **Check 11 — mind.js sync:** All commands, skills, and agents present in the repo have corresponding nodes in `docs/javascripts/mind.js`. `/notes` and `/flowie` command nodes verified present. `phase-notes` and `phase-flowie` skill nodes verified present. `notes` and `flowie` agent nodes verified present. PASS
+- **Check 12 — Flowie path hygiene:** No stale `.neuroflow/.flowie/` paths found in commands, skills, agents, or hooks. `flowie_profile:` occurrences in `commands/flowie.md` and `agents/sentinel-dev.md` and `agents/sentinel.md` are documentation text describing the old field name to detect — not live broken references. PASS
+- **docs/changelog.md:** `## 0.2.12` entry present with correct content. PASS
 
 ---
 
@@ -133,11 +53,6 @@ These appear to be **LaTeX poster template examples** (placeholder author email 
 
 | # | Severity | Check | Status |
 |---|----------|-------|--------|
-| 1 | 🔴 BLOCKING | sa-bar-version stuck at v0.2.8 | fix: update `docs/index.md` |
-| 2 | 🔴 BLOCKING | `docs/skills/setup/SKILL.md` missing | fix: create the file |
-| 3 | 🟡 MEDIUM | hooks README vs hooks.json mismatch | fix: update README Hooks table |
-| 4 | 🟡 MEDIUM | `flowie` agent not in mkdocs.yml nav | optional: add to Agents nav |
-| 5 | 🔴 BLOCKING | docs/ flowie copies have stale paths | fix: sync from source files |
-| 6 | 🔵 NOTE | `setup` naming overlap (skill + command) | no action required |
-| 7 | 🔵 NOTE | neuroflow-develop placeholder refs | no action required |
-| 8 | 🔵 NOTE | poster SKILL.md email-like strings | human review |
+| 1 | BLOCKING | `docs/skills/setup/SKILL.md` missing — dead mkdocs nav link | fix: create the file |
+
+All other checks passed.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@
 
 ---
 
+## What's new in 0.2.12
+
+- **Notes → flowie sync** ([`/notes`](commands/notes.md)) — after every notes session, Claude offers to copy the formatted note to `.neuroflow/flowie/notes/` for GitHub sync (default: yes); a local `config.json` stores per-project defaults for type, speaker, and project relation
+- **Daily wellbeing tracking** ([`/flowie --assess`](commands/flowie.md)) — opt-in daily self-assessment for anxiety, energy, and happiness on a 1–10 scale (5=neutral); stored in `flowie/wellbeing/`; Claude prompts on any sync operation if today's entry is missing; enabled via `/flowie --init` or `/flowie --assess`
+
 ## What's new in 0.2.11
 
 - **Removed broken `pubmed-mcp-server`** — replaced by `paper-search-mcp-nodejs` (the biorxiv server), which already includes `search_pubmed` and requires no credentials; `PUBMED_EMAIL` is no longer needed

--- a/commands/flowie.md
+++ b/commands/flowie.md
@@ -10,6 +10,8 @@ reads:
   - .neuroflow/flowie/sync.json
   - .neuroflow/flowie/tasks/config.json
   - .neuroflow/flowie/projects/projects.json
+  - .neuroflow/flowie/wellbeing/config.json
+  - .neuroflow/flowie/wellbeing/*.json
 writes:
   - .neuroflow/flowie/profile.md
   - .neuroflow/flowie/ideas.md
@@ -17,6 +19,9 @@ writes:
   - .neuroflow/flowie/tasks/**
   - .neuroflow/flowie/projects/projects.json
   - .neuroflow/flowie/projects/*.md
+  - .neuroflow/flowie/notes/
+  - .neuroflow/flowie/wellbeing/config.json
+  - .neuroflow/flowie/wellbeing/*.json
   - .neuroflow/project_config.md
   - .neuroflow/sessions/YYYY-MM-DD.md
 ---
@@ -180,6 +185,11 @@ Create `.neuroflow/flowie/` and scaffold the full structure:
     meeting/ .flow
     done/    .flow
     archive/ .flow
+  notes/
+    .flow                        ← index of notes synced from /notes
+  wellbeing/
+    .flow
+    config.json                  ← collect flag and metric definitions
 ```
 
 **Root `.flow` file** (neuroflow index convention):
@@ -194,6 +204,8 @@ Create `.neuroflow/flowie/` and scaffold the full structure:
 | sync.json | GitHub repo URL and last_synced |
 | projects/ | project registry |
 | tasks/ | Kanban task board |
+| notes/ | notes synced from /notes sessions |
+| wellbeing/ | daily wellbeing assessments |
 ```
 
 **`sync.json`:**
@@ -286,6 +298,36 @@ Each column folder (`inbox/`, `ready/`, `active/`, `review/`, `meeting/`, `done/
 Tasks in this column.
 ```
 
+**`notes/.flow`:**
+```markdown
+# notes
+
+| file | description |
+|---|---|
+```
+
+**`wellbeing/.flow`:**
+```markdown
+# wellbeing
+
+| file | description |
+|---|---|
+| config.json | collection settings |
+```
+
+**`wellbeing/config.json`:**
+```json
+{
+  "collect": false,
+  "metrics": [
+    {"id": "anxiety",   "label": "Anxiety",   "scale": "1=none, 5=normal, 10=very high"},
+    {"id": "energy",    "label": "Energy",    "scale": "1=depleted, 5=normal, 10=very high"},
+    {"id": "happiness", "label": "Happiness", "scale": "1=very low, 5=normal, 10=very high"}
+  ],
+  "prompt_on_sync": true
+}
+```
+
 Update `.neuroflow/flow.md` to add a row for `flowie/`.
 
 **Init and push to GitHub:**
@@ -326,6 +368,7 @@ flowie — what would you like to do?
   --identify    Generate a "who you are" paragraph from existing data
   --tasks       Show Kanban board / manage tasks
   --projects    Show / manage project registry
+  --assess      Log today's wellbeing (anxiety, energy, happiness 1–10)
   --credentials Show custom LLM settings as ready-to-paste export commands
 ```
 
@@ -353,6 +396,12 @@ Ask each question one at a time. Do not rush.
 5. *"Are there any methodological stances you hold firmly? (e.g. preregistration is non-negotiable, Bayesian over frequentist, open data always)"*
 6. *"List 3 to 5 beliefs you hold about your field that guide your research decisions. These can be controversial."*
 7. *"Is there anything else you want Claude to know about how you think — your research values, pet peeves, or preferences?"*
+8. *"Would you like to track your daily wellbeing — anxiety, energy, and happiness on a 1–10 scale? Claude will prompt you to fill in a rating each day when you sync flowie. [y/N]"*
+
+   If yes: read `wellbeing/config.json`, set `collect` to `true`, write the file, then push:
+   ```bash
+   git -C .neuroflow/flowie add wellbeing/config.json && git -C .neuroflow/flowie commit -m "wellbeing: enable daily tracking" && git -C .neuroflow/flowie push || true
+   ```
 
 After collecting all answers, write a structured `profile.md`:
 
@@ -435,6 +484,10 @@ Update `last_synced` in `sync.json` to current ISO 8601 timestamp, then commit t
 git -C .neuroflow/flowie add sync.json && git -C .neuroflow/flowie commit -m "sync: update last_synced" && git -C .neuroflow/flowie push || true
 ```
 
+### Wellbeing check
+
+After the push step, read `wellbeing/config.json`. If `collect` is `true` and `prompt_on_sync` is `true`, check whether `wellbeing/{today}.json` exists. If it does not exist, run the `--assess` flow inline before reporting (see Mode: --assess). If it exists, skip silently.
+
 Report:
 ```
 Sync complete — {YYYY-MM-DD HH:MM}
@@ -498,6 +551,8 @@ Pull first:
 ```bash
 git -C .neuroflow/flowie pull --rebase origin main || true
 ```
+
+After pulling, run the wellbeing check (same as in `--sync`): if `wellbeing/config.json` has `collect: true` and today's entry is missing, run `--assess` inline before continuing.
 
 Read `projects/projects.json`. List the available projects:
 
@@ -646,6 +701,8 @@ Flat list of all tasks across all non-archive columns, sorted by column order th
 
 ### --tasks --add
 
+Before starting, run the wellbeing check: if `wellbeing/config.json` has `collect: true` and today's entry is missing, run `--assess` inline before proceeding.
+
 Mini interview to create a new task. Ask:
 
 1. *"Task title?"*
@@ -757,6 +814,8 @@ Only show phases that have been visited or are current/future relative to `curre
 
 ### --projects --add
 
+Before starting, run the wellbeing check: if `wellbeing/config.json` has `collect: true` and today's entry is missing, run `--assess` inline before proceeding.
+
 Register a new project. Ask:
 
 1. *"Project ID (short name, no spaces — e.g. AlphaModulation)?"*
@@ -817,6 +876,62 @@ Push:
 ```bash
 git -C .neuroflow/flowie add projects/projects.json projects/{id}.md && git -C .neuroflow/flowie commit -m "projects: add {id}" && git -C .neuroflow/flowie push || true
 ```
+
+---
+
+## Mode: --assess
+
+**Trigger:** user runs `/flowie --assess`, or invoked automatically when `collect: true` and today's entry is missing (during `--sync`, `--link`, `--tasks --add`, `--projects --add`).
+
+Pull first (skip if already pulled this session).
+
+Read `wellbeing/config.json`. If `collect` is `false`:
+
+```
+Wellbeing tracking is disabled. Enable it? [y/N]
+```
+
+If yes: set `collect: true`, write `wellbeing/config.json`, push. If no: stop.
+
+Check whether `wellbeing/{today}.json` exists. If it already exists:
+
+```
+Wellbeing already logged for today ({today}). Update it? [y/N]
+```
+
+If no: stop.
+
+Ask each metric one at a time:
+
+```
+Anxiety today? (1=none, 5=normal, 10=very high) [1–10]:
+Energy today? (1=depleted, 5=normal, 10=very high) [1–10]:
+Happiness today? (1=very low, 5=normal, 10=very high) [1–10]:
+Any notes? (optional — press enter to skip):
+```
+
+Validate that each score is an integer 1–10. Re-ask if invalid.
+
+Write `wellbeing/{today}.json`:
+
+```json
+{
+  "date": "{today}",
+  "anxiety": N,
+  "energy": N,
+  "happiness": N,
+  "notes": ""
+}
+```
+
+Update `wellbeing/.flow` — append a row: `| {today}.json | wellbeing entry |`.
+
+Push:
+```bash
+git -C .neuroflow/flowie add wellbeing/{today}.json wellbeing/.flow && git -C .neuroflow/flowie commit -m "wellbeing: {today}" && git -C .neuroflow/flowie push || true
+```
+
+Confirm: `Wellbeing logged for {today}.`
 
 ---
 

--- a/commands/notes.md
+++ b/commands/notes.md
@@ -6,10 +6,13 @@ reads:
   - .neuroflow/project_config.md
   - .neuroflow/flow.md
   - .neuroflow/notes/flow.md
+  - .neuroflow/notes/config.json
   - skills/phase-notes/SKILL.md
 writes:
   - .neuroflow/notes/
   - .neuroflow/notes/flow.md
+  - .neuroflow/notes/config.json
+  - .neuroflow/flowie/notes/
   - .neuroflow/sessions/YYYY-MM-DD.md
 ---
 
@@ -25,11 +28,15 @@ Captures live notes during a meeting, talk, lab session, or supervisory meeting,
 
 ## Steps
 
+### 0 — Load config
+
+Before asking the context question, read `.neuroflow/notes/config.json` if it exists. Use `default_type` as the pre-filled suggestion for context, and `default_speaker` as the optional pre-fill for speaker. If the file does not exist, proceed with no defaults — it will be created at Step 4.
+
 ### 1 — Setup
 
 Ask a few quick questions before starting:
-- What is the context? (meeting, conference talk, lab session, supervisory meeting, other)
-- Who is involved? (speakers, attendees — optional)
+- What is the context? (meeting, conference talk, lab session, supervisory meeting, other) — suggest `default_type` from config if set
+- Who is involved? (speakers, attendees — optional) — suggest `default_speaker` from config if set
 - Location or event name? (optional)
 
 ### 2 — Live capture
@@ -50,6 +57,49 @@ Once done, reformat everything into a clean structured document:
 ### 4 — Save
 
 Save as `notes-[context]-[date].md` in `.neuroflow/notes/`. Delete the draft file `notes-[context]-[date]-draft.md` if it exists, since the final formatted file supersedes it.
+
+If `.neuroflow/notes/config.json` does not exist, create it now with standard defaults, using the current session's context as `default_type`:
+
+```json
+{
+  "sync_to_flowie": true,
+  "name_format": "{type}-{date}",
+  "default_type": "{context}",
+  "default_project": null,
+  "default_speaker": null,
+  "types": ["meeting", "conference-talk", "lab-session", "supervisory", "freeform"]
+}
+```
+
+### 5 — Flowie sync
+
+If `.neuroflow/flowie/` does not exist, skip this step silently.
+
+Read `.neuroflow/notes/config.json`. If `sync_to_flowie` is `true` (default), offer:
+
+```
+Sync this note to your flowie repo? [Y/n]
+```
+
+If the user confirms (or presses enter):
+
+1. Determine destination filename: `{YYYY-MM-DD}-{context}.md` (using today's date and the session context).
+2. If `.neuroflow/flowie/notes/` does not exist, create it with a `.flow` index file:
+   ```markdown
+   # notes
+
+   | file | description |
+   |---|---|
+   ```
+3. Write the final formatted note to `.neuroflow/flowie/notes/{filename}`.
+4. Append a row to `.neuroflow/flowie/notes/.flow`:
+   ```
+   | {filename} | {context} — {date} |
+   ```
+
+The existing auto-sync hook will push the note to GitHub automatically.
+
+If `sync_to_flowie` is `false`, skip without prompting.
 
 ---
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,13 @@ title: Changelog
 
 ---
 
+## 0.2.12
+
+- **Notes → flowie sync** ([`/notes`](commands/notes.md)) — after every notes session, Claude offers to copy the formatted note to `.neuroflow/flowie/notes/` for GitHub sync (default: yes); a local `config.json` stores per-project defaults for type, speaker, and project relation
+- **Daily wellbeing tracking** ([`/flowie --assess`](commands/flowie.md)) — opt-in daily self-assessment for anxiety, energy, and happiness on a 1–10 scale (5=neutral); stored in `flowie/wellbeing/`; Claude prompts on any sync operation if today's entry is missing; enabled via `/flowie --init` or `/flowie --assess`
+
+---
+
 ## 0.2.11
 
 - **Removed broken `pubmed-mcp-server`** — `pubmed-mcp-server@1.0.0` on npm has an empty `dist/index.js` (TypeScript was never compiled before publishing); removed from `plugin.json`; PubMed search is now handled by `paper-search-mcp-nodejs` (the biorxiv server) which already includes `search_pubmed` and requires no credentials; `PUBMED_EMAIL` is no longer needed and has been removed from the setup wizard, skills, commands, and docs

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ hide:
 ---
 
 <div class="sa-bar">
-  <span class="sa-bar-label">🧠 self-assessment <span class="sa-bar-version">v0.2.10</span></span>
+  <span class="sa-bar-label">🧠 self-assessment <span class="sa-bar-version">v0.2.12</span></span>
   <div class="sa-items">
     <span class="sa-item" data-tip="Prediction error detected?">
       <span class="sa-q-short">Pred. error</span><span class="probe-badge probe-yes">YES</span>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,7 +93,7 @@ markdown_extensions:
   - pymdownx.smartsymbols
 
 extra:
-  version: "0.2.11"
+  version: "0.2.12"
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/stanislavjiricek/neuroflow

--- a/skills/phase-flowie/SKILL.md
+++ b/skills/phase-flowie/SKILL.md
@@ -87,6 +87,24 @@ The flowie profile is mirrored to a private GitHub repository. The sync protocol
 - When generating any external-facing document, treat profile data as context only — do not quote stances or beliefs in the output.
 - If a project is being exported (via `/export`), `.neuroflow/flowie/` is excluded by default. Confirm explicitly before including it.
 
+## Wellbeing tracking
+
+The flowie repo contains a `wellbeing/` folder for daily self-assessments. The feature is opt-in (`collect: false` by default) and enabled either during `--init` or via `/flowie --assess`.
+
+**Structure:**
+- `wellbeing/config.json` — `collect` flag, metric definitions (anxiety/energy/happiness 1–10), `prompt_on_sync` flag
+- `wellbeing/YYYY-MM-DD.json` — one entry per day with integer scores and optional free-text notes
+
+**When to prompt:** On any write operation (`--sync`, `--link`, `--tasks --add`, `--projects --add`), check if `collect: true` and today's entry is missing. If so, run `--assess` inline before proceeding. Do NOT prompt during read-only modes (`--view`, `--identify`, `--credentials`).
+
+**Scale:** 1–10 with 5 as the neutral baseline. For anxiety: 10=very high anxiety. For energy and happiness: 10=very high.
+
+**Enabling mid-session:** Running `/flowie --assess` when `collect: false` will offer to enable tracking before collecting the entry.
+
+## Notes sync
+
+After every `/notes` session, the command offers to copy the formatted note to `.neuroflow/flowie/notes/` (default: yes, controlled by `sync_to_flowie` in `.neuroflow/notes/config.json`). The existing auto-sync hook pushes to GitHub. The `notes/` folder in flowie acts as a cross-project note archive.
+
 ## Slash command
 
 When this skill is invoked directly (without `/flowie`), run the full `/flowie` workflow — show the mode menu and proceed from there. Mention `/neuroflow:flowie` at the end.

--- a/skills/phase-notes/SKILL.md
+++ b/skills/phase-notes/SKILL.md
@@ -24,6 +24,8 @@ The notes phase captures live notes during a meeting, talk, or session, then ref
 - Save the final formatted notes to `.neuroflow/notes/notes-[date].md`
 - Delete the draft file once the final formatted file has been written
 - Keep the raw capture separate from the reformatted version if both are useful
+- After saving, check `.neuroflow/notes/config.json` for `sync_to_flowie`; if `true` (default), offer to copy the note to `.neuroflow/flowie/notes/` for GitHub sync
+- `.neuroflow/notes/config.json` stores per-project defaults: `default_type`, `default_speaker`, `default_project`, and `sync_to_flowie`; create it with standard defaults on first run if absent
 
 ## Slash command
 


### PR DESCRIPTION
- /notes now offers to copy final note to .neuroflow/flowie/notes/ after every session (default: yes); .neuroflow/notes/config.json stores per-project defaults for type, speaker, and project relation
- /flowie --assess: opt-in daily 1–10 self-assessment for anxiety, energy, happiness; stored in flowie/wellbeing/YYYY-MM-DD.json; collect:false by default; enabled during --init or via --assess
- wellbeing check runs automatically on --sync, --link, --tasks --add, --projects --add when collect:true and today's entry is missing
- flowie scaffold updated to include notes/ and wellbeing/ folders with config templates
- phase-flowie skill updated with wellbeing tracking and notes sync sections