### PR TITLE
feat: Karpathy wiki + concept mind map (0.2.14)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "neuroflow",
       "source": "./",
       "description": "End-to-end research workflow plugin for neuroscience teams — from hypothesis to publication. Supports EEG, iEEG, fMRI, eye tracking, ECG, and multimodal recordings.",
-      "version": "0.2.13",
+      "version": "0.2.14",
       "author": {
         "name": "Stanislav Jiricek"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neuroflow",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "End-to-end research workflow plugin for neuroscience teams — from hypothesis to publication. Supports EEG, iEEG, fMRI, eye tracking, ECG, and other neuroscience modalities.",
   "author": {
     "name": "Stanislav Jiricek"

--- a/.neuroflow/project_config.md
+++ b/.neuroflow/project_config.md
@@ -1,7 +1,7 @@
 # neuroflow — project config
 
 **Project:** neuroflow Claude Code plugin
-**Plugin version:** 0.2.13
+**Plugin version:** 0.2.14
 **Phase:** active development
 **Repo:** https://github.com/stanislavjiricek/neuroflow
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@
 
 ---
 
+## What's new in 0.2.14
+
+- **Personal wiki** ([`/flowie --wiki-*`](commands/flowie.md)) — Karpathy-style LLM-maintained knowledge base inside your flowie repo; ingest sources, query your accumulated knowledge, lint for orphan/stale pages, and build a compounding synthesis; every page is tagged to flowie projects; integrates with `/notes`, `/ideation`, `/data-analyze`, and `/paper` via closing prompts
+- **New [`neuroflow:wiki`](skills/wiki/SKILL.md) skill** — full wiki behavior: page types and frontmatter schema, ingest/query/lint/add/schema workflows, project tagging (always prompted), ideas.md sync, profile.md evolution, fails integration for method pages, and sentinel health checks
+
 ## What's new in 0.2.13
 
 - **[`/autoresearch`](commands/autoresearch.md)** — infinite improvement loop for any research artifact: point it at any file(s), and a worker-evaluator cycle runs indefinitely (one focused change per iteration, keep or revert, loop never stops until interrupted); live progress dashboard at `localhost:8765`; per-phase criteria auto-loaded from existing project memory; triggers via `/autoresearch` or any phase command with the word `autoresearch` in the prompt
@@ -274,6 +279,7 @@ Skills are invoked by Claude automatically when relevant, or triggered explicitl
 | [`neuroflow:phase-search`](skills/phase-search/SKILL.md) | Phase guidance for /search — tag-based scoping, flow.md-first indexing strategy, compact summary format |
 | [`neuroflow:phase-pipeline`](skills/phase-pipeline/SKILL.md) | Phase guidance for /pipeline — interactive vs brutal mode behaviour, pipeline plan format, resume logic, error handling |
 | [`neuroflow:phase-flowie`](skills/phase-flowie/SKILL.md) | Phase guidance for /flowie — profile read and apply rules, write rules for `.neuroflow/flowie/`, GitHub sync protocol, cross-phase personalization |
+| [`neuroflow:wiki`](skills/wiki/SKILL.md) | Personal wiki — Karpathy-style LLM-maintained knowledge base in flowie; ingest/query/lint/add workflows, project tagging, ideas.md sync, and sentinel integration |
 | [`neuroflow:phase-poster`](skills/phase-poster/SKILL.md) | LaTeX poster generation — five templates (A0/A1/A2, portrait/landscape, US size), QR code integration, template selection guide, content extraction logic |
 | [`neuroflow:notebooklm`](skills/notebooklm/SKILL.md) | Complete API for Google NotebookLM — create notebooks, add sources, generate all artifact types (podcast, video, slide deck, infographic, report, quiz, flashcards, mind map), and download results in multiple formats |
 | [`neuroflow:phase-hive`](skills/phase-hive/SKILL.md) | Team-level knowledge layer — connects a researcher's project to a shared GitHub org repo where team directions, cross-project findings, and recommended methods are coordinated; all sharing is explicit |

--- a/agents/sentinel.md
+++ b/agents/sentinel.md
@@ -131,6 +131,21 @@ Flag any failed sub-check as a warning (not a blocking error — flowie may be i
 
 Auto-fix: for the flow.md listing, offer to add the missing row. All other issues require user action (re-running `/flowie` or `/flowie --link`).
 
+### 12 — Wiki structure (if present)
+
+This check only runs if `.neuroflow/flowie/wiki/` exists.
+
+- **index.md:** check that `wiki/index.md` exists. If it exists, verify the "Last updated" date is within the past 90 days — flag if stale.
+- **log.md:** check that `wiki/log.md` exists and is non-empty.
+- **schema.md:** check that `wiki/schema.md` exists. If missing, flag — the wiki has no operating guide and `/flowie --wiki-schema` should be run to create one.
+- **raw/ and pages/:** check that both directories exist. Flag if missing.
+- **Orphan check (light):** count files in `wiki/pages/` that are not listed in `wiki/index.md`. If more than 5 are missing, flag as index drift — suggest running `/flowie --wiki-lint`.
+- **Log vs pages consistency:** read the last 10 entries in `wiki/log.md`. For any `ingest` entry, check whether a corresponding file exists in `wiki/pages/sources/`. Flag any mismatches.
+
+Group all wiki warnings under a single "⚠️ wiki" section in the report. These are warnings, not blocking errors.
+
+Auto-fix: none — all wiki issues require user action via `/flowie --wiki-lint` or `/flowie --wiki-schema`.
+
 ## Report
 
 Write to `.neuroflow/sentinel.md`:

--- a/commands/data-analyze.md
+++ b/commands/data-analyze.md
@@ -52,3 +52,10 @@ Save the analysis plan and results summary in `.neuroflow/data-analyze/`. Write 
 - Update `.neuroflow/data-analyze/flow.md`
 - Append to `.neuroflow/sessions/YYYY-MM-DD.md`
 - Update `project_config.md` if phase changed
+
+If `.neuroflow/flowie/wiki/` exists, add a closing nudge:
+
+```
+Consider synthesizing key findings into your personal wiki:
+  /flowie --wiki-ingest .neuroflow/data-analyze/analysis-summary.md
+```

--- a/commands/flowie.md
+++ b/commands/flowie.md
@@ -1,6 +1,6 @@
 ---
 name: flowie
-description: Personal research OS — link a private GitHub repository to store your research profile, cross-project Kanban task board, and project registry with phase tracking. Supports profile creation, task management, project registry, GitHub sync, phase auto-tracking, and credential export.
+description: Personal research OS — link a private GitHub repository to store your research profile, cross-project Kanban task board, project registry, and personal wiki. Supports profile creation, task management, project registry, GitHub sync, phase auto-tracking, credential export, and LLM-maintained personal knowledge base.
 phase: utility
 reads:
   - .neuroflow/project_config.md
@@ -12,6 +12,11 @@ reads:
   - .neuroflow/flowie/projects/projects.json
   - .neuroflow/flowie/wellbeing/config.json
   - .neuroflow/flowie/wellbeing/*.json
+  - .neuroflow/flowie/wiki/schema.md
+  - .neuroflow/flowie/wiki/index.md
+  - .neuroflow/flowie/wiki/log.md
+  - .neuroflow/flowie/wiki/pages/**
+  - skills/wiki/SKILL.md
 writes:
   - .neuroflow/flowie/profile.md
   - .neuroflow/flowie/ideas.md
@@ -22,21 +27,23 @@ writes:
   - .neuroflow/flowie/notes/
   - .neuroflow/flowie/wellbeing/config.json
   - .neuroflow/flowie/wellbeing/*.json
+  - .neuroflow/flowie/wiki/
   - .neuroflow/project_config.md
   - .neuroflow/sessions/YYYY-MM-DD.md
 ---
 
 # /flowie
 
-Personal research OS for neuroflow. Links the current project to a private GitHub repository — the user's `flowie` repo — which stores three layers of research infrastructure:
+Personal research OS for neuroflow. Links the current project to a private GitHub repository — the user's `flowie` repo — which stores four layers of research infrastructure:
 
 1. **Identity layer** — `profile.md`, `ideas.md`: research stances, writing style, methodological preferences, cross-project hypotheses
 2. **Kanban task board** — `tasks/`: column-per-folder, task-per-.md-file, ASCII board view
 3. **Project registry** — `projects/`: `projects.json` machine index + one `{name}.md` per project with phase timeline
+4. **Personal wiki** — `wiki/`: LLM-maintained knowledge base with indexed pages, source summaries, concept synthesis, and method library
 
 The `flowie` directory at `.neuroflow/flowie/` **is the git repo itself** — cloned from GitHub. GitHub is canonical. Pull before every read, push after every write.
 
-Read the `neuroflow:phase-flowie` skill first. Then follow the neuroflow-core lifecycle: read `project_config.md` and `flow.md` before starting.
+Read the `neuroflow:phase-flowie` skill first. For any `--wiki-*` mode, also read the `neuroflow:wiki` skill. Then follow the neuroflow-core lifecycle: read `project_config.md` and `flow.md` before starting.
 
 Flowie is fully optional. Nothing breaks if it is not set up.
 
@@ -370,6 +377,14 @@ flowie — what would you like to do?
   --projects    Show / manage project registry
   --assess      Log today's wellbeing (anxiety, energy, happiness 1–10)
   --credentials Show custom LLM settings as ready-to-paste export commands
+
+  Personal wiki (powered by neuroflow:wiki skill):
+  --wiki        Show wiki overview — page count, recent activity, index summary
+  --wiki-ingest Ingest a new source into your wiki
+  --wiki-query  Ask a question answered from your wiki
+  --wiki-lint   Health-check the wiki — orphans, contradictions, stale pages
+  --wiki-add    Manually create or update a wiki page
+  --wiki-schema View or update the wiki's operating conventions
 ```
 
 Wait for the user to choose.
@@ -935,6 +950,85 @@ Confirm: `Wellbeing logged for {today}.`
 
 ---
 
+---
+
+## Wiki modes — `--wiki-*`
+
+All wiki modes load the `neuroflow:wiki` skill and follow its full operation workflows. The wiki lives at `.neuroflow/flowie/wiki/`. The skill file defines all page formats, index/log conventions, ingest/query/lint/add workflows, and the neuroflow-specific integrations (project tagging, ideas.md sync, profile evolution, fails integration).
+
+Pull before every wiki read operation:
+```bash
+git -C .neuroflow/flowie pull --rebase origin main || true
+```
+
+Push after every wiki write:
+```bash
+git -C .neuroflow/flowie add -A && git -C .neuroflow/flowie commit -m "wiki: {description}" && git -C .neuroflow/flowie push || true
+```
+
+### Mode: --wiki
+
+Show the wiki at a glance:
+
+1. Read `wiki/index.md` (if exists) — report page count by type
+2. Read last 5 lines of `wiki/log.md` — show recent activity
+3. Print:
+
+```
+wiki — personal knowledge base
+  Pages:  {N total} ({n} concepts, {n} sources, {n} synthesis, {n} entities, {n} methods)
+  Recent: {last 5 log entries}
+  Size:   {raw/ folder: N files}
+
+  --wiki-ingest   Add a new source
+  --wiki-query    Ask a question
+  --wiki-lint     Health check
+  --wiki-add      Create a page manually
+  --wiki-schema   View/edit wiki conventions
+```
+
+If `wiki/` does not exist: tell the user and offer to initialize via `--wiki-schema`.
+
+### Mode: --wiki-ingest [path|text]
+
+Load `neuroflow:wiki` skill. Follow the **Ingest workflow** defined there. Key steps:
+
+1. Read `schema.md` (create starter via interview if missing — this initializes the wiki)
+2. Read the source file or accept pasted text from the user
+3. Discuss: ask what to emphasize, any framing context
+4. **Read `projects/projects.json`** → suggest active project names → ask for `projects:` tags (mandatory — always ask)
+5. Write source page, update affected pages, create missing concept/entity/method pages, update `index.md`, append to `log.md`
+6. Push to GitHub
+7. After ingest: ask whether it cross-links to `ideas.md` or warrants a `profile.md` stance update
+
+If no path or text provided, ask: "What would you like to ingest? (paste text, or give me a file path)"
+
+### Mode: --wiki-query [question]
+
+Load `neuroflow:wiki` skill. Follow the **Query workflow** defined there. Key steps:
+
+1. Read `schema.md` + `index.md`
+2. Identify and read relevant pages
+3. Synthesize answer with citations
+4. Ask whether to file the answer as a synthesis page (with `projects:` tagging)
+5. Append to `log.md`, push if anything written
+
+If no question provided, ask: "What would you like to know from your wiki?"
+
+### Mode: --wiki-lint
+
+Load `neuroflow:wiki` skill. Follow the **Lint workflow** defined there. Check for: orphan pages, stale pages, missing concept pages, missing project tags, log/page mismatches, cross-reference gaps, methods without fails check. Report findings and offer iterative fixes.
+
+### Mode: --wiki-add [title]
+
+Load `neuroflow:wiki` skill. Follow the **Add workflow** defined there. Guides the user through creating or updating a specific page with type, tags, project links, and body content.
+
+### Mode: --wiki-schema
+
+Load `neuroflow:wiki` skill. Follow the **Schema workflow** defined there. If `wiki/` does not exist, run **Initialization** to scaffold the full structure and generate a starter `schema.md` through a brief interview.
+
+---
+
 ## Phase sync (called programmatically by /phase)
 
 This section is invoked automatically when the active phase in `project_config.md` changes. It is not a user-facing mode — `/phase` calls this logic after updating its own state.
@@ -988,3 +1082,9 @@ Examples:
 - `[15:40] /flowie — --tasks --move: moved fix-rt-glasses → active`
 - `[16:00] /flowie — --projects: showed phase timeline for 2 projects`
 - `[16:10] /flowie — --projects --add: registered project RT_DES`
+- `[16:30] /flowie — --wiki: showed wiki overview (24 pages, 8 sources)`
+- `[16:45] /flowie — --wiki-ingest: ingested "Gamma in WM" paper, updated 6 pages, tagged AlphaModulation`
+- `[17:00] /flowie — --wiki-query: answered "what do I know about ICA?", filed as synthesis page`
+- `[17:20] /flowie — --wiki-lint: found 3 orphan pages, 1 missing concept page, fixed 2`
+- `[17:30] /flowie — --wiki-add: created method page for "FOOOF spectral parameterization"`
+- `[17:45] /flowie — --wiki-schema: initialized wiki for EEG/cognition domain`

--- a/commands/notes.md
+++ b/commands/notes.md
@@ -103,6 +103,19 @@ If `sync_to_flowie` is `false`, skip without prompting.
 
 ---
 
+### 6 — Wiki ingest offer
+
+If `.neuroflow/flowie/wiki/` exists (the user has a personal wiki set up), offer after the flowie sync step:
+
+```
+Extract key insights into your personal wiki? Run:
+  /flowie --wiki-ingest .neuroflow/notes/{filename}
+```
+
+This is a nudge only — do not run the ingest automatically. The user chooses when to do it.
+
+---
+
 ## At end
 
 - Update `.neuroflow/notes/flow.md`

--- a/commands/paper.md
+++ b/commands/paper.md
@@ -93,3 +93,10 @@ Write loop state to `.neuroflow/paper/critic-log.md` after each iteration using 
 - Confirm that session entries were appended to `.neuroflow/sessions/YYYY-MM-DD.md` after each section verdict during the session — if any were missed, append them now
 - Confirm that any framing or scope decisions were written to `.neuroflow/reasoning/paper.json` as they occurred — if any were missed, append them now
 - Update `project_config.md` if phase changed
+
+If `.neuroflow/flowie/wiki/` exists, add a closing nudge:
+
+```
+Consider archiving key findings and methods in your personal wiki:
+  /flowie --wiki-ingest .neuroflow/paper/
+```

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,13 @@ title: Changelog
 
 ---
 
+## 0.2.14
+
+- **Personal wiki** ([`/flowie --wiki-*`](commands/flowie.md)) — Karpathy-style LLM-maintained knowledge base inside your flowie repo; ingest sources, query accumulated knowledge, lint for orphans/contradictions/stale pages; every page is tagged to flowie projects; closing prompts in `/notes`, `/ideation`, `/data-analyze`, and `/paper`
+- **New [`neuroflow:wiki`](skills/wiki/SKILL.md) skill** — page types/frontmatter schema, ingest/query/lint/add/schema workflows, project tagging (always prompted), ideas.md and profile.md sync, fails integration for method pages, sentinel Check 12 for wiki health
+
+---
+
 ## 0.2.13
 
 - **`/autoresearch`** — infinite worker-evaluator loop for any research artifact; per-phase criteria auto-loaded; live dashboard at localhost:8765; triggers via `/autoresearch` or any phase command + `autoresearch` keyword

--- a/docs/javascripts/mind.js
+++ b/docs/javascripts/mind.js
@@ -1,301 +1,227 @@
-/* ── Neuroflow Mind — interactive universe visualization ──────────────────── */
-/* Activated only on the /mind page. Uses D3 v7 (loaded dynamically).        */
+/* ── Neuroflow Mind — concept map visualization ────────────────────────────── */
+/* Activated only on the /mind page. Uses D3 v7 (loaded dynamically).         */
 
 (function () {
   "use strict";
 
   /* ── Graph data ──────────────────────────────────────────────────────────── */
+
   var NODES = [
-    /* ── Core ── */
+    /* ── Personal Profile ── */
     {
-      id: "core", label: ".neuroflow/", type: "core",
-      tags: ["memory"],
-      desc: "Shared project memory — the brain that all commands read and write. Stores reasoning logs, session notes, phase folders, and configuration across every session.",
+      id: "c-profile",  label: "Research Profile",     category: "personal-profile",
+      desc: "Your identity as a researcher — stances, writing voice, methodological preferences. Read silently by every phase to shape assistance.",
+      commands: ["/flowie --init", "/flowie --view", "/flowie --identify"],
+      url: "commands/flowie/"
+    },
+    {
+      id: "c-wiki",     label: "Personal Wiki",         category: "personal-profile",
+      desc: "Karpathy-style second brain — ingest sources, synthesize knowledge across sessions, query your accumulated understanding, lint for orphans and contradictions.",
+      commands: ["/flowie --wiki-ingest", "/flowie --wiki-query", "/flowie --wiki-lint", "/flowie --wiki-add"],
+      url: "skills/wiki/SKILL/"
+    },
+    {
+      id: "c-tasks",    label: "Task Board",            category: "personal-profile",
+      desc: "Cross-project Kanban board — inbox / active / review / done. One markdown file per task, linked to a flowie project entry.",
+      commands: ["/flowie --tasks", "/flowie --tasks --add", "/flowie --tasks --move"],
+      url: "commands/flowie/"
+    },
+    {
+      id: "c-wellbeing",label: "Wellbeing",             category: "personal-profile",
+      desc: "Opt-in daily self-assessment — anxiety, energy, and happiness on a 1–10 scale (5 = neutral). Prompted automatically on sync if enabled.",
+      commands: ["/flowie --assess"],
+      url: "commands/flowie/"
+    },
+    {
+      id: "c-registry", label: "Project Registry",     category: "personal-profile",
+      desc: "Phase timelines across all your research projects. Links repos to flowie project entries and auto-updates when you change phase.",
+      commands: ["/flowie --projects", "/flowie --link"],
+      url: "commands/flowie/"
+    },
+    {
+      id: "c-ideas",    label: "Cross-project Ideas",  category: "personal-profile",
+      desc: "Hypotheses and insights that span multiple projects. Feeds into the personal wiki and can evolve into new research directions.",
+      commands: ["/flowie --wiki-ingest", "/flowie --view"],
+      url: "commands/flowie/"
+    },
+
+    /* ── Project Memory ── */
+    {
+      id: "c-memory",   label: "Project Memory",       category: "project",
+      desc: "Per-project knowledge store at .neuroflow/ — sessions, reasoning logs, flow index, phase subfolders, objectives. The persistent brain every command reads and writes.",
+      commands: ["/neuroflow", "/setup", "/phase"],
       url: "concepts/project-memory/"
     },
 
-    /* ── Commands ── */
-    { id: "cmd-neuroflow",       label: "/neuroflow",       type: "command", phase: "utility",        tags: ["memory","human"],           desc: "Main entry point. Greets you, scans the project, runs the setup interview, and creates the .neuroflow/ memory structure.",                                         url: "commands/neuroflow/" },
-    { id: "cmd-setup",           label: "/setup",           type: "command", phase: "utility",        tags: ["memory","human"],           desc: "Reconfigure project settings — updates project_config.md and prompts for any missing metadata.",                                                                  url: "commands/setup/" },
-    { id: "cmd-phase",           label: "/phase",           type: "command", phase: "utility",        tags: ["memory"],                   desc: "Show or switch the current research phase. Updates project_config.md and refreshes the flow index.",                                                               url: "commands/phase/" },
-    { id: "cmd-search",          label: "/search",          type: "command", phase: "utility",        tags: ["literature","memory"],      desc: "Search PubMed and bioRxiv for relevant literature using PICO queries via the scholar agent.",                                                                      url: "commands/search/" },
-    { id: "cmd-sentinel",        label: "/sentinel",        type: "command", phase: "utility",        tags: ["memory"],                   desc: "Audit your project memory — checks for completeness, consistency, and stale entries across all .neuroflow/ subfolders.",                                           url: "commands/sentinel/" },
-    { id: "cmd-git",             label: "/git",             type: "command", phase: "utility",        tags: ["code","memory"],            desc: "Version control integration — commit, branch, tag, and review diffs for your research project.",                                                                   url: "commands/git/" },
-    { id: "cmd-output",          label: "/output",          type: "command", phase: "output",         tags: ["memory","code"],            desc: "Output project memory or the whole project — pack it as a zip archive or copy it to a target location for sharing, archiving, or handoff.",                      url: "commands/output/" },
-    { id: "cmd-interview",       label: "/interview",       type: "command", phase: "utility",        tags: ["human"],                    desc: "Run an interactive interview to capture or update project context stored in project_config.md.",                                                                   url: "commands/interview/" },
-    { id: "cmd-quiz",            label: "/quiz",            type: "command", phase: "utility",        tags: ["human","literature"],       desc: "Test your neuroscience knowledge with AI-generated spaced-repetition quizzes tailored to your research domain.",                                                   url: "commands/quiz/" },
-    { id: "cmd-fails",           label: "/fails",           type: "command", phase: "utility",        tags: ["human","memory"],           desc: "Log and review failed experiments or analysis attempts. Structured failure reports help avoid repeating mistakes.",                                                 url: "commands/fails/" },
-    { id: "cmd-idk",             label: "/idk",             type: "command", phase: "utility",        tags: ["human"],                    desc: "Express and document uncertainty — flags knowledge gaps in project memory so they can be resolved later.",                                                         url: "commands/idk/" },
-    { id: "cmd-pipeline",        label: "/pipeline",        type: "command", phase: "utility",        tags: ["memory","code"],            desc: "Multi-step orchestration — chain commands in sequence with optional --nomistake brutal-review mode.",                                                              url: "commands/pipeline/" },
-    { id: "cmd-ideation",        label: "/ideation",        type: "command", phase: "ideation",       tags: ["literature","human"],       desc: "Brainstorm research questions, search PubMed and bioRxiv via the scholar agent, and formalize a project proposal.",                                                url: "commands/ideation/" },
-    { id: "cmd-preregistration", label: "/preregistration", type: "command", phase: "preregistration",tags: ["writing","stats"],          desc: "Formalize hypotheses and analysis plan before data collection. Generates OSF-compatible preregistration documents.",                                                 url: "commands/preregistration/" },
-    { id: "cmd-grant-proposal",  label: "/grant-proposal",  type: "command", phase: "grant-proposal", tags: ["writing"],                  desc: "Write a full grant application — specific aims, significance, innovation, approach, budget, and timeline.",                                                       url: "commands/grant-proposal/" },
-    { id: "cmd-finance",         label: "/finance",         type: "command", phase: "finance",        tags: ["writing"],                  desc: "Research budget tracking and financial planning — personnel, equipment, consumables, indirect costs.",                                                              url: "commands/finance/" },
-    { id: "cmd-experiment",      label: "/experiment",      type: "command", phase: "experiment",     tags: ["eeg","code"],               desc: "Design a PsychoPy paradigm, define recording parameters, and configure LSL hardware integration for your modality.",                                               url: "commands/experiment/" },
-    { id: "cmd-tool-build",      label: "/tool-build",      type: "command", phase: "tool-build",     tags: ["code","eeg"],               desc: "Build custom analysis tools and scripts — MNE pipelines, custom classifiers, or domain-specific utilities.",                                                       url: "commands/tool-build/" },
-    { id: "cmd-tool-validate",   label: "/tool-validate",   type: "command", phase: "tool-validate",  tags: ["code","stats"],             desc: "Validate analysis tools with unit tests, benchmarks, and synthetic data to ensure correctness before use on real data.",                                           url: "commands/tool-validate/" },
-    { id: "cmd-data",            label: "/data",            type: "command", phase: "data",           tags: ["eeg","fmri","memory"],      desc: "Locate, inventory, validate BIDS structure, and convert raw data formats. Generates a data intake report.",                                                        url: "commands/data/" },
-    { id: "cmd-data-preprocess", label: "/data-preprocess", type: "command", phase: "data-preprocess",tags: ["eeg","fmri","code"],        desc: "Build and run a preprocessing pipeline — filtering, ICA, epoching, artifact rejection, and QC reports.",                                                           url: "commands/data-preprocess/" },
-    { id: "cmd-data-analyze",    label: "/data-analyze",    type: "command", phase: "data-analyze",   tags: ["stats","ml","eeg"],         desc: "ERPs, time-frequency, connectivity, decoding, GLM — with built-in stats auditing for reproducibility.",                                                           url: "commands/data-analyze/" },
-    { id: "cmd-paper",           label: "/paper",           type: "command", phase: "paper",          tags: ["writing","stats"],          desc: "Unified manuscript command — drafts each section with paper-writer, then runs it through paper-critic in a brutal write→critique loop before saving.",              url: "commands/paper/" },
-    { id: "cmd-review",          label: "/review",          type: "command", phase: "review",         tags: ["writing","stats"],          desc: "Peer reviewer command — you are the referee. Reads a colleague's paper and produces a structured six-area referee report via the review-neuro skill.",          url: "commands/review/" },
-    { id: "cmd-notes",           label: "/notes",           type: "command", phase: "notes",          tags: ["human","memory"],           desc: "Capture session notes, meeting minutes, and ad-hoc observations in structured format to .neuroflow/notes/.",                                                       url: "commands/notes/" },
-    { id: "cmd-write-report",    label: "/write-report",    type: "command", phase: "write-report",   tags: ["writing","memory"],         desc: "Generate a project status or phase summary report from .neuroflow/ contents.",                                                                                    url: "commands/write-report/" },
-    { id: "cmd-brain-build",     label: "/brain-build",     type: "command", phase: "brain-build",    tags: ["brain-sim","code"],         desc: "Build a computational neural model with NEURON, Brian2, NetPyNE, or NEST.",                                                                                       url: "commands/brain-build/" },
-    { id: "cmd-brain-optimize",  label: "/brain-optimize",  type: "command", phase: "brain-optimize", tags: ["brain-sim","stats"],        desc: "Tune model parameters to match experimental data — sensitivity analysis, fitting algorithms.",                                                                     url: "commands/brain-optimize/" },
-    { id: "cmd-brain-run",       label: "/brain-run",       type: "command", phase: "brain-run",      tags: ["brain-sim","code"],         desc: "Execute neural simulations and collect output metrics, logs, and visualizations.",                                                                                 url: "commands/brain-run/" },
-    { id: "cmd-flowie",          label: "/flowie",          type: "command", phase: "flowie",         tags: ["human","memory"],           desc: "Personal research OS — link a private GitHub repo as identity profile + Kanban task board + project registry with phase tracking. Supports --tasks (board/add/move/done), --projects (list/add), --sync, --link, --init, --identify.",     url: "commands/flowie/" },
-    { id: "cmd-hive",            label: "/hive",            type: "command", phase: "hive",           tags: ["memory","human"],           desc: "Connect neuroflow to a shared team GitHub org repo for research direction coordination and explicit knowledge sharing. Never auto-shares personal project data.",                                         url: "commands/hive/" },
-    { id: "cmd-slideshow",       label: "/slideshow",       type: "command", phase: "slideshow",      tags: ["writing","human"],          desc: "Build a presentation from selected project areas — pick phases, figures, and key findings, then get a structured slide deck ready to export.",                   url: "commands/slideshow/" },
-    { id: "cmd-poster",          label: "/poster",          type: "command", phase: "poster",         tags: ["writing","human"],          desc: "Generate a LaTeX conference poster from project memory — five templates (A0/A1, portrait/landscape, US size), QR code support, and iterative poster-critic review loop.",  url: "commands/poster/" },
-    { id: "cmd-autoresearch",    label: "/autoresearch",    type: "command", phase: "utility",        tags: ["memory","code"],            desc: "Infinite improvement loop — point at any files and a worker-evaluator cycle runs indefinitely: one change per iteration, keep or revert, live dashboard at localhost:8765.", url: "commands/autoresearch/" },
+    /* ── Research Pipeline ── */
+    {
+      id: "c-discovery",     label: "Discovery",       category: "pipeline",
+      desc: "Ideation, literature search, brainstorming. The scholar agent runs sequential searches across bioRxiv and runs a 12-lens analytical review of downloaded papers.",
+      commands: ["/ideation", "/search"],
+      url: "commands/ideation/"
+    },
+    {
+      id: "c-formalization", label: "Formalization",   category: "pipeline",
+      desc: "Preregistration, hypothesis formalization, open science. Generates OSF-compatible documents. Constrains what data collection and analysis can do.",
+      commands: ["/preregistration"],
+      url: "commands/preregistration/"
+    },
+    {
+      id: "c-funding",       label: "Funding",         category: "pipeline",
+      desc: "Grant writing (NIH R01/R21, ERC, Wellcome, DFG) and budget tracking. Runs in parallel with hypothesis formalization.",
+      commands: ["/grant-proposal", "/finance"],
+      url: "commands/grant-proposal/"
+    },
+    {
+      id: "c-experiment",    label: "Experiment",      category: "pipeline",
+      desc: "Paradigm design in PsychoPy, LSL hardware integration, BIDS recording parameters, eye-tracking setup. Shaped by the preregistration.",
+      commands: ["/experiment", "/tool-build", "/tool-validate"],
+      url: "commands/experiment/"
+    },
+    {
+      id: "c-data",          label: "Data",            category: "pipeline",
+      desc: "BIDS structure validation, data ingestion, format conversion (EDF, BrainVision, NWB), preprocessing pipeline — filtering, ICA, epoching, QC reports.",
+      commands: ["/data", "/data-preprocess"],
+      url: "commands/data/"
+    },
+    {
+      id: "c-analysis",      label: "Analysis",        category: "pipeline",
+      desc: "ERPs, time-frequency, connectivity, decoding, GLM, brain simulation (NEURON, Brian2, NetPyNE, NEST). Results with built-in reproducibility auditing.",
+      commands: ["/data-analyze", "/brain-build", "/brain-optimize", "/brain-run"],
+      url: "commands/data-analyze/"
+    },
+    {
+      id: "c-writing",       label: "Writing",         category: "pipeline",
+      desc: "Manuscripts and peer review. Every section goes through a write→critique loop (paper-writer + paper-critic agents) before anything is saved.",
+      commands: ["/paper", "/review"],
+      url: "commands/paper/"
+    },
+    {
+      id: "c-communication", label: "Communication",   category: "pipeline",
+      desc: "Posters (LaTeX, 5 templates), slide decks, phase reports, and project output archives. Final outputs from the research pipeline.",
+      commands: ["/poster", "/slideshow", "/write-report", "/output"],
+      url: "commands/poster/"
+    },
 
-    /* ── Skills ── */
-    { id: "sk-core",          label: "neuroflow-core",         type: "skill", tags: ["memory"],              desc: "Core lifecycle rules — what every command must read, write, and follow across all phases.",                                           url: "skills/neuroflow-core/SKILL/" },
-    { id: "sk-develop",       label: "neuroflow-develop",      type: "skill", tags: ["code","memory"],       desc: "Development guide — how to add new skills, commands, agents, and hooks to the neuroflow plugin.",                                    url: "skills/neuroflow-develop/SKILL/" },
-    { id: "sk-creator",       label: "skill-creator",          type: "skill", tags: ["code"],                desc: "Guide for creating and structuring new neuroflow skills, including overlap audits and frontmatter conventions.",                     url: "skills/skill-creator/SKILL/" },
-    { id: "sk-ideation",      label: "phase-ideation",         type: "skill", tags: ["literature"],          desc: "Neuroscience ideation best practices — hypothesis formation, literature strategy, feasibility assessment.",                          url: "skills/phase-ideation/SKILL/" },
-    { id: "sk-prereg",        label: "phase-preregistration",  type: "skill", tags: ["writing","stats"],     desc: "Preregistration guidelines — OSF templates, CONSORT, STROBE, AsPredicted formats.",                                                url: "skills/phase-preregistration/SKILL/" },
-    { id: "sk-grant",         label: "phase-grant-proposal",   type: "skill", tags: ["writing"],             desc: "Grant writing strategy — NIH R01/R21, ERC, Wellcome Trust, DFG formats and review criteria.",                                       url: "skills/phase-grant-proposal/SKILL/" },
-    { id: "sk-finance",       label: "phase-finance",          type: "skill", tags: ["writing"],             desc: "Research budget planning and financial compliance — personnel costs, equipment, indirect rates.",                                     url: "skills/phase-finance/SKILL/" },
-    { id: "sk-experiment",    label: "phase-experiment",       type: "skill", tags: ["eeg","code"],          desc: "Experiment design — PsychoPy paradigms, LSL hardware integration, BIDS recording parameters.",                                      url: "skills/phase-experiment/SKILL/" },
-    { id: "sk-tool-build",    label: "phase-tool-build",       type: "skill", tags: ["code","eeg"],          desc: "Tool development — MNE pipelines, custom analysis scripts, code quality, and documentation.",                                       url: "skills/phase-tool-build/SKILL/" },
-    { id: "sk-tool-validate", label: "phase-tool-validate",    type: "skill", tags: ["code","stats"],        desc: "Validation strategies — unit tests, benchmarks, synthetic data, and edge-case coverage.",                                           url: "skills/phase-tool-validate/SKILL/" },
-    { id: "sk-data",          label: "phase-data",             type: "skill", tags: ["eeg","fmri","memory"], desc: "Data management — BIDS structure, provenance tracking, format conversion (EDF, BrainVision, NWB).",                                 url: "skills/phase-data/SKILL/" },
-    { id: "sk-data-pre",      label: "phase-data-preprocess",  type: "skill", tags: ["eeg","fmri","code"],   desc: "Preprocessing — filtering, ICA, epoching, artifact rejection, channel interpolation, QC.",                                          url: "skills/phase-data-preprocess/SKILL/" },
-    { id: "sk-data-analyze",  label: "phase-data-analyze",     type: "skill", tags: ["stats","ml"],          desc: "Analysis methods — ERPs, TFR, connectivity, decoding, GLM, and statistical testing.",                                               url: "skills/phase-data-analyze/SKILL/" },
-    { id: "sk-paper",         label: "phase-paper",            type: "skill", tags: ["writing"],             desc: "Unified paper phase — write→critique loop guidance, section order, critic rubric, and critic-log conventions.",                     url: "skills/phase-paper/SKILL/" },
-    { id: "sk-phase-review",  label: "phase-review",           type: "skill", tags: ["writing","stats"],     desc: "Peer reviewer orientation — external referee posture, journal calibration, delegation to review-neuro, output to reviews/ folder.", url: "skills/phase-review/SKILL/" },
-    { id: "sk-notes",         label: "phase-notes",            type: "skill", tags: ["human"],               desc: "Note-taking conventions — structured session logs, meeting minutes, and observation formats.",                                       url: "skills/phase-notes/SKILL/" },
-    { id: "sk-write-report",  label: "phase-write-report",     type: "skill", tags: ["writing"],             desc: "Report generation — executive summaries, phase milestone reports, and stakeholder-ready formats.",                                  url: "skills/phase-write-report/SKILL/" },
-    { id: "sk-brain-build",   label: "phase-brain-build",      type: "skill", tags: ["brain-sim"],           desc: "Neural simulation model building — NEURON, Brian2, NetPyNE, NEST, tvb-library model definitions.",                                  url: "skills/phase-brain-build/SKILL/" },
-    { id: "sk-brain-opt",     label: "phase-brain-optimize",   type: "skill", tags: ["brain-sim","stats"],   desc: "Model optimization — parameter tuning, sensitivity analysis, fitting algorithms.",                                                  url: "skills/phase-brain-optimize/SKILL/" },
-    { id: "sk-brain-run",     label: "phase-brain-run",        type: "skill", tags: ["brain-sim"],           desc: "Simulation execution — runtime configs, parallel runs, output collection and checkpointing.",                                       url: "skills/phase-brain-run/SKILL/" },
-    { id: "sk-git",           label: "phase-git",              type: "skill", tags: ["code"],                desc: "Version control conventions — branching strategy, commit message standards, tagging releases.",                                      url: "skills/phase-git/SKILL/" },
-    { id: "sk-pipeline",      label: "phase-pipeline",         type: "skill", tags: ["code","memory"],       desc: "Pipeline orchestration — multi-step workflows, dependency ordering, --nomistake strict mode.",                                       url: "skills/phase-pipeline/SKILL/" },
-    { id: "sk-search",        label: "phase-search",           type: "skill", tags: ["literature"],          desc: "Literature search — PubMed PICO queries, bioRxiv preprints, synthesis and citation management.",                                    url: "skills/phase-search/SKILL/" },
-    { id: "sk-output",        label: "phase-output",           type: "skill", tags: ["code","memory"],       desc: "Output conventions - ZIP archives, folder copies, shareable exports; always excludes credentials and session logs.",                                    url: "skills/phase-output/SKILL/" },
-    { id: "sk-fails",         label: "phase-fails",            type: "skill", tags: ["human"],               desc: "Failure logging — structured failure reports, root-cause analysis, lessons learned.",                                               url: "skills/phase-fails/SKILL/" },
-    { id: "sk-quiz",          label: "phase-quiz",             type: "skill", tags: ["human"],               desc: "Quiz generation — spaced repetition, domain-specific neuroscience questions, progress tracking.",                                   url: "skills/phase-quiz/SKILL/" },
-    { id: "sk-review-neuro",  label: "review-neuro",           type: "skill", tags: ["writing","stats"],     desc: "Expert neuroscience manuscript review — rigorous scientific critique of methods, statistics, and interpretation.",                  url: "skills/review-neuro/SKILL/" },
-    { id: "sk-flowie",        label: "phase-flowie",           type: "skill", tags: ["human","memory"],     desc: "Personal research OS skill — read/apply flowie profile, Kanban task context, write rules for .neuroflow/flowie/, GitHub sync protocol, and cross-phase personalization.",                          url: "skills/phase-flowie/SKILL/" },
-    { id: "sk-hive",          label: "phase-hive",             type: "skill", tags: ["memory","human"],     desc: "Team-level knowledge layer — connects a researcher's neuroflow project to a shared GitHub org repo for coordinating directions, sharing findings, and team-aware recommendations.",                 url: "skills/phase-hive/SKILL/" },
-    { id: "sk-slideshow",     label: "phase-slideshow",        type: "skill", tags: ["writing"],            desc: "Presentation guidance — slide structure decisions, format selection, and audience calibration for building slide decks from project memory.",                                                        url: "skills/phase-slideshow/SKILL/" },
-    { id: "sk-poster",        label: "phase-poster",           type: "skill", tags: ["writing"],            desc: "LaTeX poster generation — five conference templates (A0/A1, portrait/landscape, US size), QR code blocks, content extraction from project memory, and compilation instructions.",                 url: "skills/phase-poster/SKILL/" },
-    { id: "sk-notebooklm",   label: "notebooklm",             type: "skill", tags: ["literature","human"], desc: "Google NotebookLM integration — create notebooks, add sources, generate podcasts, quizzes, infographics, slide decks, and mind maps from research materials.",                                    url: "skills/notebooklm/SKILL/" },
-    { id: "sk-pupil-labs",   label: "pupil-labs-neon",        type: "skill", tags: ["eeg","code"],         desc: "Pupil Labs Neon real-time eye-tracking — connect to Neon glasses and collect live gaze, video, and IMU streams via the Real-time API.",                                                               url: "skills/pupil-labs-neon-realtime/SKILL/" },
-    { id: "sk-worker-critic",label: "worker-critic",          type: "skill", tags: ["code"],               desc: "Worker-critic agentic loop — orchestrator coordinates a worker and a critic across up to 3 revision cycles to produce a vetted output for any phase.",                                              url: "skills/worker-critic/SKILL/" },
-    { id: "sk-humanizer",    label: "humanizer",              type: "skill", tags: ["writing"],            desc: "Remove AI writing signatures from prose — varied rhythm, natural register, no AI tells. Use when any text needs to read as genuinely human-authored.",                                            url: "skills/humanizer/SKILL/" },
-    { id: "sk-setup",          label: "setup",                  type: "skill", tags: ["memory","human"],  desc: "Configure neuroflow integrations — PubMed, Miro, Google Workspace, and custom LLM providers. Use when setting up credentials, checking integration status, or connecting external services.",  url: "skills/setup/SKILL/" },
-    { id: "sk-autoresearch",   label: "autoresearch",           type: "skill", tags: ["memory","code"],   desc: "Autoresearch protocol — never-stop loop rules, per-phase criteria, three-layer criteria init, evaluator format, and embedded dashboard server template.",                                    url: "skills/autoresearch/SKILL/" },
+    /* ── Team Integration ── */
+    {
+      id: "c-team",     label: "Team Integration",     category: "team",
+      desc: "Hive — shared GitHub org repo for team-level knowledge. Coordinates research directions and surfaces cross-project findings. All sharing is explicit, never automatic.",
+      commands: ["/hive"],
+      url: "commands/hive/"
+    },
 
-    /* ── Agents ── */
-    { id: "ag-scholar",      label: "scholar",          type: "agent", tags: ["literature"],         desc: "Literature search specialist — sequential PubMed → bioRxiv pipeline, paper synthesis, batch PDF downloads.",                                                                             url: "concepts/agents/" },
-    { id: "ag-sentinel",     label: "sentinel",         type: "agent", tags: ["memory"],             desc: "Audit specialist — project memory completeness, phase consistency, stale-entry detection.",                                                                                              url: "concepts/agents/" },
-    { id: "ag-sentinel-dev", label: "sentinel-dev",     type: "agent", tags: ["code","memory"],      desc: "Dev audit specialist — plugin integrity checks, overlap detection, version consistency.",                                                                                                url: "concepts/agents/" },
-    { id: "ag-flowie",       label: "flowie",           type: "agent", tags: ["human","memory"],     desc: "Personal identity agent — reads flowie profile and surfaces active tasks for the current project at session start; shapes assistance to the user's intellectual fingerprint.",          url: "concepts/agents/" },
-    { id: "ag-paper-writer", label: "paper-writer",     type: "agent", tags: ["writing"],            desc: "Manuscript writer — drafts neuroscience manuscript sections from upstream project memory inside a brutal write→critique loop with the paper-critic agent.",                             url: "concepts/agents/" },
-    { id: "ag-paper-critic", label: "paper-critic",     type: "agent", tags: ["writing","stats"],    desc: "Hyper-critical manuscript reviewer — applies full six-area review-neuro methodology to every draft and returns APPROVED or REJECTED with zero tolerance for overclaims.",               url: "concepts/agents/" },
-    { id: "ag-lit-review",   label: "literature-review",type: "agent", tags: ["literature"],         desc: "Literature review specialist — runs 12 sequential analytical lenses on downloaded papers using the worker-critic loop to ensure rigour. Scoped to the ideation phase.",                url: "concepts/agents/" },
-    { id: "ag-poster-critic",label: "poster-critic",    type: "agent", tags: ["writing"],            desc: "Conference poster critic — audits every LaTeX poster draft across five areas; returns APPROVED or REJECTED with specific, actionable feedback; operates inside the /poster loop.",      url: "concepts/agents/" },
-    { id: "ag-autoresearch", label: "autoresearch",     type: "agent", tags: ["memory","code"],      desc: "Infinite loop controller — coordinates the worker-evaluator cycle, keeps or reverts each iteration against history snapshots, manages results.md and the dashboard. Never stops.",      url: "concepts/agents/" }
+    /* ── Utilities & Quality ── */
+    {
+      id: "c-quality",    label: "Quality & Audit",   category: "utilities",
+      desc: "Sentinel (11 consistency checks on .neuroflow/ structure, preregistration drift, sensitive data), fails log (structured failure reports), and tool validation.",
+      commands: ["/sentinel", "/fails", "/tool-validate"],
+      url: "commands/sentinel/"
+    },
+    {
+      id: "c-automation", label: "Automation",        category: "utilities",
+      desc: "Autoresearch infinite worker-evaluator loop (any artifact, any phase, live dashboard), multi-step pipeline orchestration, and hook triggers on tool events.",
+      commands: ["/autoresearch", "/pipeline"],
+      url: "commands/autoresearch/"
+    },
+    {
+      id: "c-utilities",  label: "Utilities",         category: "utilities",
+      desc: "Git version control, scoped search, phase tracking, notes capture, quiz, interview, and idk — the everyday tools that keep a project running.",
+      commands: ["/git", "/search", "/notes", "/quiz", "/interview", "/phase", "/idk"],
+      url: "commands/git/"
+    }
   ];
 
   var LINKS = [
-    /* Every command reads/writes core */
-    { source: "cmd-neuroflow",       target: "core", type: "rw" },
-    { source: "cmd-setup",           target: "core", type: "rw" },
-    { source: "sk-setup",            target: "cmd-setup", type: "uses" },
-    { source: "cmd-phase",           target: "core", type: "rw" },
-    { source: "cmd-search",          target: "core", type: "rw" },
-    { source: "cmd-sentinel",        target: "core", type: "rw" },
-    { source: "cmd-git",             target: "core", type: "rw" },
-    { source: "cmd-output",          target: "core", type: "rw" },
-    { source: "cmd-flowie",          target: "core", type: "rw" },
-    { source: "cmd-hive",            target: "core", type: "rw" },
-    { source: "cmd-slideshow",       target: "core", type: "r"  },
-    { source: "cmd-poster",          target: "core", type: "rw" },
-    { source: "cmd-interview",       target: "core", type: "rw" },
-    { source: "cmd-quiz",            target: "core", type: "r"  },
-    { source: "cmd-fails",           target: "core", type: "rw" },
-    { source: "cmd-idk",             target: "core", type: "rw" },
-    { source: "cmd-pipeline",        target: "core", type: "r"  },
-    { source: "cmd-ideation",        target: "core", type: "rw" },
-    { source: "cmd-preregistration", target: "core", type: "rw" },
-    { source: "cmd-grant-proposal",  target: "core", type: "rw" },
-    { source: "cmd-finance",         target: "core", type: "rw" },
-    { source: "cmd-experiment",      target: "core", type: "rw" },
-    { source: "cmd-tool-build",      target: "core", type: "rw" },
-    { source: "cmd-tool-validate",   target: "core", type: "rw" },
-    { source: "cmd-data",            target: "core", type: "rw" },
-    { source: "cmd-data-preprocess", target: "core", type: "rw" },
-    { source: "cmd-data-analyze",    target: "core", type: "rw" },
-    { source: "cmd-paper",           target: "core", type: "rw" },
-    { source: "cmd-review",          target: "core", type: "rw" },
-    { source: "cmd-notes",           target: "core", type: "rw" },
-    { source: "cmd-write-report",    target: "core", type: "rw" },
-    { source: "cmd-brain-build",     target: "core", type: "rw" },
-    { source: "cmd-brain-optimize",  target: "core", type: "rw" },
-    { source: "cmd-brain-run",       target: "core", type: "rw" },
+    /* Personal Profile internal */
+    { source: "c-profile",  target: "c-wiki",          type: "knowledge" },
+    { source: "c-wiki",     target: "c-ideas",         type: "knowledge" },
+    { source: "c-tasks",    target: "c-registry",      type: "coordination" },
 
-    /* Commands ↔ Skills */
-    { source: "sk-core",          target: "cmd-neuroflow",       type: "uses" },
-    { source: "sk-core",          target: "cmd-setup",           type: "uses" },
-    { source: "sk-core",          target: "cmd-phase",           type: "uses" },
-    { source: "sk-develop",       target: "cmd-neuroflow",       type: "uses" },
-    { source: "sk-ideation",      target: "cmd-ideation",        type: "uses" },
-    { source: "sk-prereg",        target: "cmd-preregistration", type: "uses" },
-    { source: "sk-grant",         target: "cmd-grant-proposal",  type: "uses" },
-    { source: "sk-finance",       target: "cmd-finance",         type: "uses" },
-    { source: "sk-experiment",    target: "cmd-experiment",      type: "uses" },
-    { source: "sk-tool-build",    target: "cmd-tool-build",      type: "uses" },
-    { source: "sk-tool-validate", target: "cmd-tool-validate",   type: "uses" },
-    { source: "sk-data",          target: "cmd-data",            type: "uses" },
-    { source: "sk-data-pre",      target: "cmd-data-preprocess", type: "uses" },
-    { source: "sk-data-analyze",  target: "cmd-data-analyze",    type: "uses" },
-    { source: "sk-paper",         target: "cmd-paper",           type: "uses" },
-    { source: "sk-phase-review",  target: "cmd-review",          type: "uses" },
-    { source: "sk-notes",         target: "cmd-notes",           type: "uses" },
-    { source: "sk-write-report",  target: "cmd-write-report",    type: "uses" },
-    { source: "sk-brain-build",   target: "cmd-brain-build",     type: "uses" },
-    { source: "sk-brain-opt",     target: "cmd-brain-optimize",  type: "uses" },
-    { source: "sk-brain-run",     target: "cmd-brain-run",       type: "uses" },
-    { source: "sk-git",           target: "cmd-git",             type: "uses" },
-    { source: "sk-pipeline",      target: "cmd-pipeline",        type: "uses" },
-    { source: "sk-search",        target: "cmd-search",          type: "uses" },
-    { source: "sk-output",        target: "cmd-output",          type: "uses" },
-    { source: "sk-fails",          target: "cmd-fails",           type: "uses" },
-    { source: "sk-quiz",           target: "cmd-quiz",            type: "uses" },
-    { source: "sk-flowie",         target: "cmd-flowie",          type: "uses" },
-    { source: "sk-hive",           target: "cmd-hive",            type: "uses" },
-    { source: "sk-slideshow",      target: "cmd-slideshow",       type: "uses" },
-    { source: "sk-poster",         target: "cmd-poster",          type: "uses" },
+    /* Profile → Pipeline */
+    { source: "c-profile",  target: "c-writing",       type: "knowledge" },
+    { source: "c-profile",  target: "c-discovery",     type: "knowledge" },
 
-    /* Commands → Agents (spawns) */
-    { source: "cmd-ideation",        target: "ag-scholar",       type: "spawns" },
-    { source: "cmd-search",          target: "ag-scholar",       type: "spawns" },
-    { source: "cmd-sentinel",        target: "ag-sentinel",      type: "spawns" },
-    { source: "cmd-flowie",          target: "ag-flowie",        type: "spawns" },
-    { source: "cmd-paper",           target: "ag-paper-writer",  type: "spawns" },
-    { source: "cmd-paper",           target: "ag-paper-critic",  type: "spawns" },
-    { source: "cmd-poster",          target: "ag-poster-critic", type: "spawns" },
-    { source: "cmd-ideation",        target: "ag-lit-review",    type: "spawns" },
-    { source: "cmd-autoresearch",    target: "ag-autoresearch",  type: "spawns" },
+    /* Wiki → Pipeline */
+    { source: "c-wiki",     target: "c-discovery",     type: "knowledge" },
 
-    /* Autoresearch */
-    { source: "cmd-autoresearch",    target: "core",              type: "rw" },
-    { source: "sk-autoresearch",     target: "cmd-autoresearch",  type: "uses" },
+    /* Ideas → Discovery */
+    { source: "c-ideas",    target: "c-discovery",     type: "knowledge" },
 
-    /* Pipeline orchestrates many commands */
-    { source: "cmd-pipeline", target: "cmd-ideation",        type: "orchestrates" },
-    { source: "cmd-pipeline", target: "cmd-data-preprocess", type: "orchestrates" },
-    { source: "cmd-pipeline", target: "cmd-data-analyze",    type: "orchestrates" },
-    { source: "cmd-pipeline", target: "cmd-paper",         type: "orchestrates" }
+    /* Registry → Memory */
+    { source: "c-registry", target: "c-memory",        type: "storage" },
+
+    /* Memory ↔ Pipeline (stores) */
+    { source: "c-memory",   target: "c-discovery",     type: "storage" },
+    { source: "c-memory",   target: "c-analysis",      type: "storage" },
+    { source: "c-memory",   target: "c-writing",       type: "storage" },
+
+    /* Memory ↔ Quality */
+    { source: "c-quality",  target: "c-memory",        type: "storage" },
+
+    /* Research pipeline flow */
+    { source: "c-discovery",     target: "c-formalization", type: "pipeline" },
+    { source: "c-formalization", target: "c-funding",       type: "pipeline" },
+    { source: "c-formalization", target: "c-experiment",    type: "pipeline" },
+    { source: "c-experiment",    target: "c-data",          type: "pipeline" },
+    { source: "c-data",          target: "c-analysis",      type: "pipeline" },
+    { source: "c-analysis",      target: "c-writing",       type: "pipeline" },
+    { source: "c-writing",       target: "c-communication", type: "pipeline" },
+
+    /* Automation → Pipeline */
+    { source: "c-automation", target: "c-analysis",    type: "improvement" },
+    { source: "c-automation", target: "c-writing",     type: "improvement" },
+    { source: "c-automation", target: "c-memory",      type: "improvement" },
+
+    /* Team */
+    { source: "c-team",     target: "c-memory",        type: "coordination" },
+    { source: "c-team",     target: "c-discovery",     type: "coordination" },
+
+    /* Utilities → Memory */
+    { source: "c-utilities", target: "c-memory",       type: "storage" }
   ];
 
   /* ── Visual config ───────────────────────────────────────────────────────── */
-  var TYPE_CONFIG = {
-    core:    { color: "#ce93d8", glow: "#9c27b0", radius: 28, ring: 0 },
-    command: { color: "#7c4dff", glow: "#651fff", radius: 12, ring: 1 },
-    skill:   { color: "#26c6da", glow: "#00acc1", radius: 9,  ring: 2 },
-    agent:   { color: "#66bb6a", glow: "#43a047", radius: 9,  ring: 3 }
+  var CATEGORY_CONFIG = {
+    "personal-profile": { color: "#ce93d8", glow: "#9c27b0", radius: 13 },
+    "project":          { color: "#ffd54f", glow: "#f9a825", radius: 17 },
+    "pipeline":         { color: "#7c4dff", glow: "#651fff", radius: 13 },
+    "team":             { color: "#66bb6a", glow: "#43a047", radius: 13 },
+    "utilities":        { color: "#26c6da", glow: "#00acc1", radius: 13 }
   };
 
-  /* ── Tag receptor colors ─────────────────────────────────────────────────── */
-  /* Each tag is shown as a small colored dot (receptor) on the node surface.  */
-  var TAG_CONFIG = {
-    "memory":    { color: "#ce93d8", label: "memory" },
-    "literature":{ color: "#ffd54f", label: "literature" },
-    "eeg":       { color: "#26c6da", label: "EEG / ephys" },
-    "fmri":      { color: "#ef5350", label: "fMRI / imaging" },
-    "brain-sim": { color: "#ec407a", label: "brain simulation" },
-    "stats":     { color: "#ffa726", label: "statistics" },
-    "ml":        { color: "#42a5f5", label: "machine learning" },
-    "code":      { color: "#66bb6a", label: "code / tools" },
-    "writing":   { color: "#ab47bc", label: "scientific writing" },
-    "human":     { color: "#ff7043", label: "human interaction" }
+  var CATEGORY_LABELS = {
+    "personal-profile": "PERSONAL PROFILE",
+    "project":          "PROJECT MEMORY",
+    "pipeline":         "RESEARCH PIPELINE",
+    "team":             "TEAM INTEGRATION",
+    "utilities":        "UTILITIES & QUALITY"
   };
 
+  /* ── Link type colors ────────────────────────────────────────────────────── */
   var LINK_COLORS = {
-    rw:           "rgba(206,147,216,0.45)",
-    r:            "rgba(206,147,216,0.25)",
-    uses:         "rgba(38,198,218,0.35)",
-    spawns:       "rgba(102,187,106,0.4)",
-    orchestrates: "rgba(255,183,77,0.35)"
+    "pipeline":     "rgba(124,77,255,0.45)",
+    "knowledge":    "rgba(206,147,216,0.50)",
+    "storage":      "rgba(38,198,218,0.40)",
+    "coordination": "rgba(102,187,106,0.40)",
+    "improvement":  "rgba(255,183,77,0.50)"
   };
 
-  /* ── Phase / cluster layout ───────────────────────────────────────────────── */
-  /* Clockwise degrees from 12 o'clock for each research phase.
-     Nodes are pulled toward their phase angle in concentric arcs
-     (commands inner, skills middle, agents outer).
-     Cycle: utility → ideation → … → review → back to utility.        */
-  var PHASE_ANGLES = {
-    "ideation":        15,
-    "preregistration": 42,
-    "grant-proposal":  65,
-    "finance":         88,
-    "experiment":      112,
-    "tool-build":      135,
-    "tool-validate":   158,
-    "data":            180,
-    "data-preprocess": 202,
-    "data-analyze":    224,
-    "brain-build":     248,
-    "brain-optimize":  262,
-    "brain-run":       276,
-    "paper":           298,
-    "notes":           310,
-    "write-report":    318,
-    "review":          332,
-    "slideshow":       338,
-    "poster":          341,
-    "output":          344,
-    "utility":         350,
-    "hive":            355,
-    "flowie":          359
+  var LINK_LABELS = {
+    "pipeline":     "research flow",
+    "knowledge":    "knowledge flow",
+    "storage":      "stores / audits",
+    "coordination": "coordination",
+    "improvement":  "improves"
   };
 
-  /* Phase for each skill / agent node (commands already carry d.phase) */
-  var NODE_PHASE_MAP = {
-    "sk-core":          "utility",
-    "sk-develop":       "utility",
-    "sk-creator":       "utility",
-    "sk-setup":         "utility",
-    "sk-ideation":      "ideation",
-    "sk-prereg":        "preregistration",
-    "sk-grant":         "grant-proposal",
-    "sk-finance":       "finance",
-    "sk-experiment":    "experiment",
-    "sk-tool-build":    "tool-build",
-    "sk-tool-validate": "tool-validate",
-    "sk-data":          "data",
-    "sk-data-pre":      "data-preprocess",
-    "sk-data-analyze":  "data-analyze",
-    "sk-paper":         "paper",
-    "sk-phase-review":  "review",
-    "sk-notes":         "notes",
-    "sk-write-report":  "write-report",
-    "sk-brain-build":   "brain-build",
-    "sk-brain-opt":     "brain-optimize",
-    "sk-brain-run":     "brain-run",
-    "sk-git":           "utility",
-    "sk-pipeline":      "utility",
-    "sk-search":        "utility",
-    "sk-output":        "output",
-    "sk-fails":         "utility",
-    "sk-quiz":          "utility",
-    "sk-review-neuro":  "review",
-    "ag-ideation":      "ideation",
-    "sk-notebooklm":    "utility",
-    "sk-pupil-labs":    "experiment",
-    "sk-worker-critic": "utility",
-    "ag-flowie":        "flowie",
-    "ag-orchestrator":  "utility",
-    "ag-paper-writer":  "paper",
-    "ag-paper-critic":  "paper",
-    "ag-lit-review":    "ideation",
-    "sk-poster":        "poster",
-    "ag-poster-critic": "poster"
+  /* ── Category cluster angles (clockwise degrees from 12 o'clock) ─────────── */
+  var CATEGORY_ANGLES = {
+    "personal-profile": 350,
+    "project":           45,
+    "pipeline":         180,
+    "team":             270,
+    "utilities":        310
   };
 
   /* ── State ───────────────────────────────────────────────────────────────── */
@@ -307,8 +233,6 @@
     var root = document.getElementById("nf-mind-root");
     if (!root) return;
 
-    /* Clear any previous render (instant-nav support) — remove only the SVG
-       and panel so the topbar / back-to-docs buttons are preserved. */
     root.querySelectorAll("svg, #nf-mind-panel").forEach(function(el) { el.remove(); });
 
     var W = root.clientWidth  || window.innerWidth;
@@ -332,11 +256,10 @@
       feMerge.append("feMergeNode").attr("in", "SourceGraphic");
     }
 
-    addGlow("glow-core",    "#9c27b0", 10, 3);
-    addGlow("glow-command", "#651fff", 6,  2);
-    addGlow("glow-skill",   "#00acc1", 5,  2);
-    addGlow("glow-agent",   "#43a047", 5,  2);
-    addGlow("glow-select",  "#ffffff", 8,  4);
+    Object.keys(CATEGORY_CONFIG).forEach(function(cat) {
+      addGlow("glow-" + cat, CATEGORY_CONFIG[cat].glow, 6, 2);
+    });
+    addGlow("glow-select", "#ffffff", 8, 4);
 
     /* ── Starfield background ── */
     var bg = svg.append("g").attr("class", "nf-stars");
@@ -349,66 +272,35 @@
         .attr("fill", "rgba(255,255,255," + (rng() * 0.35 + 0.05) + ")");
     }
 
-    /* ── Legend ── */
+    /* ── Category legend (top-left) ── */
     var legend = svg.append("g").attr("transform", "translate(20,20)");
-    var legendItems = [
-      { type: "core",    label: "project memory" },
-      { type: "command", label: "commands" },
-      { type: "skill",   label: "skills" },
-      { type: "agent",   label: "agents" }
-    ];
+    var legendItems = Object.keys(CATEGORY_CONFIG).map(function(cat) {
+      return { cat: cat, label: CATEGORY_LABELS[cat] };
+    });
     legendItems.forEach(function(item, i) {
       var g = legend.append("g").attr("transform", "translate(0," + (i * 22) + ")");
       g.append("circle").attr("r", 6).attr("cx", 7).attr("cy", 7)
-        .attr("fill", TYPE_CONFIG[item.type].color)
-        .attr("filter", "url(#glow-" + item.type + ")");
+        .attr("fill", CATEGORY_CONFIG[item.cat].color)
+        .attr("filter", "url(#glow-" + item.cat + ")");
       g.append("text").attr("x", 18).attr("y", 11)
         .attr("fill", "rgba(255,255,255,0.65)")
         .attr("font-size", "11px")
         .attr("font-family", "Inter, sans-serif")
-        .text(item.label);
+        .text(item.label.toLowerCase());
     });
 
-    /* ── Tag receptor legend (top-right) ── */
-    var tagKeys = Object.keys(TAG_CONFIG);
-    var tagLegend = svg.append("g").attr("transform", "translate(" + (W - 145) + ",20)");
-    tagLegend.append("text")
-      .attr("x", 0).attr("y", 0)
-      .attr("fill", "rgba(255,255,255,0.4)")
-      .attr("font-size", "10px")
-      .attr("font-family", "Inter, sans-serif")
-      .attr("font-weight", "600")
-      .attr("letter-spacing", "0.08em")
-      .text("DOMAIN TAGS");
-    tagKeys.forEach(function(key, i) {
-      var g = tagLegend.append("g").attr("transform", "translate(0," + (14 + i * 18) + ")");
-      g.append("circle").attr("r", 3.5).attr("cx", 4).attr("cy", 5)
-        .attr("fill", TAG_CONFIG[key].color)
-        .attr("opacity", 0.9);
-      g.append("text").attr("x", 13).attr("y", 9)
-        .attr("fill", "rgba(255,255,255,0.5)")
-        .attr("font-size", "10px")
-        .attr("font-family", "Inter, sans-serif")
-        .text(TAG_CONFIG[key].label);
-    });
-
-    /* ── Link type hint ── */
-    var hint = svg.append("g").attr("transform", "translate(20," + (H - 90) + ")");
-    var hintItems = [
-      { color: LINK_COLORS.rw,           label: "reads & writes" },
-      { color: LINK_COLORS.uses,         label: "skill used by command" },
-      { color: LINK_COLORS.spawns,       label: "spawns agent" },
-      { color: LINK_COLORS.orchestrates, label: "orchestrates" }
-    ];
-    hintItems.forEach(function(item, i) {
+    /* ── Link type legend (bottom-left) ── */
+    var hint = svg.append("g").attr("transform", "translate(20," + (H - 80) + ")");
+    Object.keys(LINK_LABELS).forEach(function(type, i) {
       var g = hint.append("g").attr("transform", "translate(0," + (i * 18) + ")");
       g.append("line").attr("x1", 0).attr("y1", 7).attr("x2", 22).attr("y2", 7)
-        .attr("stroke", item.color).attr("stroke-width", 2);
+        .attr("stroke", LINK_COLORS[type]).attr("stroke-width", 2)
+        .attr("stroke-dasharray", type === "coordination" ? "4,3" : null);
       g.append("text").attr("x", 28).attr("y", 11)
         .attr("fill", "rgba(255,255,255,0.5)")
         .attr("font-size", "10px")
         .attr("font-family", "Inter, sans-serif")
-        .text(item.label);
+        .text(LINK_LABELS[type]);
     });
 
     /* ── Build graph data ── */
@@ -424,75 +316,53 @@
     });
 
     /* ── Cluster layout helpers ── */
-    /* Orbit radii scale with the smaller viewport dimension so nodes always
-       fit on screen; commands innermost, skills middle, agents outermost.  */
     var viewportR = Math.min(W, H) / 2;
 
-    function nodePhase(d) {
-      return NODE_PHASE_MAP[d.id] || d.phase || "utility";
-    }
-
     function clusterAngleRad(d) {
-      var ph = nodePhase(d);
-      var deg = PHASE_ANGLES[ph] !== undefined ? PHASE_ANGLES[ph] : PHASE_ANGLES["utility"];
-      /* Convert clockwise-from-12 degrees → SVG radians (0 = right, CW = +) */
+      var deg = CATEGORY_ANGLES[d.category] !== undefined ? CATEGORY_ANGLES[d.category] : 0;
       return (deg - 90) * Math.PI / 180;
     }
 
     function clusterRadius(d) {
-      if (d.type === "core")    return 0;
-      if (d.type === "command") return viewportR * 0.48;
-      if (d.type === "skill")   return viewportR * 0.70;
-      if (d.type === "agent")   return viewportR * 0.90;
-      return viewportR * 0.70;
+      /* Project Memory sits closer to center — it connects to everything */
+      if (d.id === "c-memory") return viewportR * 0.30;
+      return viewportR * 0.60;
     }
 
     function clusterX(d) {
-      if (d.type === "core") return W / 2;
       return W / 2 + clusterRadius(d) * Math.cos(clusterAngleRad(d));
     }
 
     function clusterY(d) {
-      if (d.type === "core") return H / 2;
       return H / 2 + clusterRadius(d) * Math.sin(clusterAngleRad(d));
     }
 
-    /* Pre-position nodes near their cluster target so layout is stable
-       from the very first frame (uses a seeded RNG for reproducibility). */
+    /* Pre-position nodes near their cluster target */
     var rng2 = mulberry32(99);
     nodes.forEach(function(d) {
-      if (d.type !== "core") {
-        d.x = clusterX(d) + (rng2() - 0.5) * 20;
-        d.y = clusterY(d) + (rng2() - 0.5) * 20;
-      }
+      d.x = clusterX(d) + (rng2() - 0.5) * 20;
+      d.y = clusterY(d) + (rng2() - 0.5) * 20;
     });
 
     /* ── Force simulation ── */
     simulation = d3.forceSimulation(nodes)
       .force("link", d3.forceLink(links).id(function(d) { return d.id; }).distance(function(d) {
-        if (d.type === "rw" || d.type === "r") return 70;
-        if (d.type === "uses")     return 65;
-        if (d.type === "spawns")   return 60;
-        return 90;
-      }).strength(0.7))
+        if (d.type === "pipeline")     return 85;
+        if (d.type === "knowledge")    return 80;
+        if (d.type === "storage")      return 75;
+        if (d.type === "coordination") return 90;
+        return 80;
+      }).strength(0.6))
       .force("charge", d3.forceManyBody().strength(function(d) {
-        return d.type === "core" ? -500 : -60;
+        return d.id === "c-memory" ? -300 : -80;
       }))
-      /* Per-node attraction toward phase cluster target — replaces forceCenter */
-      .force("x", d3.forceX(function(d) { return clusterX(d); }).strength(0.22))
-      .force("y", d3.forceY(function(d) { return clusterY(d); }).strength(0.22))
-      /* Tighter collision buffer (8 vs previous 10) — nodes intentionally
-         pack closer within a cluster; forceX/Y prevents runaway separation. */
+      .force("x", d3.forceX(function(d) { return clusterX(d); }).strength(0.20))
+      .force("y", d3.forceY(function(d) { return clusterY(d); }).strength(0.20))
       .force("collision", d3.forceCollide().radius(function(d) {
-        return TYPE_CONFIG[d.type].radius + 8;
+        return CATEGORY_CONFIG[d.category].radius + 10;
       }))
       .alphaDecay(0.018)
       .velocityDecay(0.38);
-
-    /* Fix core at center */
-    var coreNode = nodeMap["core"];
-    coreNode.fx = W / 2;
-    coreNode.fy = H / 2;
 
     /* ── Draw links ── */
     var linkG = svg.append("g").attr("class", "nf-links");
@@ -501,10 +371,10 @@
       .enter().append("line")
       .attr("stroke", function(d) { return LINK_COLORS[d.type] || "rgba(255,255,255,0.2)"; })
       .attr("stroke-width", function(d) {
-        return (d.type === "rw") ? 1.5 : 1;
+        return d.type === "pipeline" || d.type === "improvement" ? 1.5 : 1;
       })
       .attr("stroke-dasharray", function(d) {
-        return d.type === "uses" ? "4,3" : null;
+        return d.type === "coordination" ? "4,3" : null;
       })
       .attr("class", "nf-link");
 
@@ -523,79 +393,42 @@
       .on("mouseover", onNodeOver)
       .on("mouseout",  onNodeOut);
 
-    /* Outer glow ring (hidden by default, shown on hover/select) */
+    /* Outer glow ring */
     nodeSel.append("circle")
       .attr("class", "nf-node-ring")
-      .attr("r", function(d) { return TYPE_CONFIG[d.type].radius + 6; })
+      .attr("r", function(d) { return CATEGORY_CONFIG[d.category].radius + 6; })
       .attr("fill", "none")
-      .attr("stroke", function(d) { return TYPE_CONFIG[d.type].color; })
+      .attr("stroke", function(d) { return CATEGORY_CONFIG[d.category].color; })
       .attr("stroke-width", 1.5)
       .attr("opacity", 0);
 
     /* Main circle */
     nodeSel.append("circle")
       .attr("class", "nf-node-circle")
-      .attr("r", function(d) { return TYPE_CONFIG[d.type].radius; })
-      .attr("fill", function(d) { return TYPE_CONFIG[d.type].color; })
-      .attr("filter", function(d) { return "url(#glow-" + d.type + ")"; })
+      .attr("r", function(d) { return CATEGORY_CONFIG[d.category].radius; })
+      .attr("fill", function(d) { return CATEGORY_CONFIG[d.category].color; })
+      .attr("filter", function(d) { return "url(#glow-" + d.category + ")"; })
       .attr("opacity", 0.92);
 
-    /* Core pulse ring */
-    nodeSel.filter(function(d) { return d.type === "core"; })
+    /* Project Memory pulse ring */
+    nodeSel.filter(function(d) { return d.id === "c-memory"; })
       .append("circle")
       .attr("class", "nf-core-pulse")
-      .attr("r", 28)
+      .attr("r", 22)
       .attr("fill", "none")
-      .attr("stroke", "#ce93d8")
+      .attr("stroke", "#ffd54f")
       .attr("stroke-width", 1.5)
       .attr("opacity", 0.5);
 
-    /* ── Tag receptor dots ── */
-    /* For each node, draw small colored dots evenly around the outer edge
-       of the main circle — one dot per tag, like membrane receptors.        */
-    /* TAG_START_ANGLE: -π/2 rotates the first dot to the 12 o'clock
-       position in SVG coordinates (where 0 rad = 3 o'clock).               */
-    var TAG_START_ANGLE = -Math.PI / 2;
-    nodeSel.each(function(d) {
-      var tags = d.tags || [];
-      if (!tags.length) return;
-      var n = tags.length;
-      var nodeR = TYPE_CONFIG[d.type].radius;
-      /* Receptor dots sit just outside the node circle */
-      var dotR = d.type === "core" ? 5 : 3;
-      var orbitR = nodeR + dotR + 2;
-      tags.forEach(function(tag, i) {
-        var angle = TAG_START_ANGLE + (i / n) * 2 * Math.PI;
-        var cx = Math.cos(angle) * orbitR;
-        var cy = Math.sin(angle) * orbitR;
-        var tagCfg = TAG_CONFIG[tag] || { color: "#ffffff" };
-        d3.select(this).append("circle")
-          .attr("class", "nf-tag-dot")
-          .attr("cx", cx)
-          .attr("cy", cy)
-          .attr("r", dotR)
-          .attr("fill", tagCfg.color)
-          .attr("stroke", "rgba(0,0,0,0.4)")
-          .attr("stroke-width", 0.5)
-          .attr("opacity", 0.9)
-          .attr("pointer-events", "none");
-      });
-    });
-
-    /* Labels — offset clears both the node circle and any receptor dots.
-       dot orbit max = radius + 2*dotR + 2 ≈ radius+8, so radius+14 is safe. */
+    /* Labels */
     nodeSel.append("text")
       .attr("class", "nf-node-label")
-      .attr("dy", function(d) {
-        /* Receptor dot orbit sits at nodeR + dotR + 2; add clearance */
-        var dotR = d.type === "core" ? 5 : 3;
-        return TYPE_CONFIG[d.type].radius + dotR + 6;
-      })
+      .attr("dy", function(d) { return CATEGORY_CONFIG[d.category].radius + 12; })
       .attr("text-anchor", "middle")
-      .attr("font-size", function(d) { return d.type === "core" ? "13px" : "10px"; })
-      .attr("font-weight", function(d) { return d.type === "core" ? "700" : "500"; })
+      .attr("font-size", function(d) { return d.id === "c-memory" ? "12px" : "10px"; })
+      .attr("font-weight", function(d) { return d.id === "c-memory" ? "700" : "500"; })
       .attr("font-family", "Inter, JetBrains Mono, monospace")
-      .attr("fill", function(d) { return d.type === "core" ? "#e1bee7" : "rgba(255,255,255,0.72)"; })
+      .attr("fill", function(d) { return d.id === "c-memory" ? "#fff8e1" : "rgba(255,255,255,0.72)"; })
       .attr("pointer-events", "none")
       .text(function(d) { return d.label; });
 
@@ -640,17 +473,14 @@
       });
     });
 
-    /* ── Core pulse animation ── */
+    /* ── Pulse animation ── */
     animatePulse();
 
     /* ── Helpers ── */
 
     function onNodeClick(event, d) {
       event.stopPropagation();
-      if (selectedId === d.id) {
-        closePanel();
-        return;
-      }
+      if (selectedId === d.id) { closePanel(); return; }
       selectedId = d.id;
       showPanel(d);
       highlightConnected(d.id);
@@ -671,7 +501,6 @@
 
     function highlightConnected(nodeId) {
       var connectedIds = new Set([nodeId]);
-      var connectedLinkTypes = {};
 
       links.forEach(function(l) {
         var srcId = l.source.id || l.source;
@@ -679,20 +508,14 @@
         if (srcId === nodeId || tgtId === nodeId) {
           connectedIds.add(srcId);
           connectedIds.add(tgtId);
-          connectedLinkTypes[srcId + "__" + tgtId] = l.type;
         }
       });
 
       nodeSel.each(function(d) {
         var connected = connectedIds.has(d.id);
-        d3.select(this).select(".nf-node-circle")
-          .transition().duration(200)
-          .attr("opacity", connected ? 1 : 0.15);
-        d3.select(this).select(".nf-node-label")
-          .transition().duration(200)
-          .attr("opacity", connected ? 1 : 0.15);
-        d3.select(this).select(".nf-node-ring")
-          .attr("opacity", d.id === nodeId ? 0.7 : (connected ? 0.35 : 0));
+        d3.select(this).select(".nf-node-circle").transition().duration(200).attr("opacity", connected ? 1 : 0.12);
+        d3.select(this).select(".nf-node-label").transition().duration(200).attr("opacity", connected ? 1 : 0.12);
+        d3.select(this).select(".nf-node-ring").attr("opacity", d.id === nodeId ? 0.7 : (connected ? 0.35 : 0));
       });
 
       linkSel.transition().duration(200)
@@ -715,32 +538,28 @@
         d3.select(this).select(".nf-node-ring").attr("opacity", 0);
       });
       linkSel.transition().duration(200).attr("opacity", 1).attr("stroke-width", function(d) {
-        return d.type === "rw" ? 1.5 : 1;
+        return d.type === "pipeline" || d.type === "improvement" ? 1.5 : 1;
       });
     }
 
     function showPanel(d) {
-      var cfg = TYPE_CONFIG[d.type];
-      var typeLabels = { core: "PROJECT MEMORY", command: "COMMAND", skill: "SKILL", agent: "AGENT" };
+      var cfg = CATEGORY_CONFIG[d.category];
 
-      panel.querySelector(".nf-mind-panel-type").textContent = typeLabels[d.type] || d.type.toUpperCase();
+      panel.querySelector(".nf-mind-panel-type").textContent = CATEGORY_LABELS[d.category] || d.category.toUpperCase();
       panel.querySelector(".nf-mind-panel-type").style.color = cfg.color;
       panel.querySelector(".nf-mind-panel-title").textContent = d.label;
       panel.querySelector(".nf-mind-panel-desc").textContent = d.desc;
 
-      /* Tags */
+      /* Commands list (replaces tags) */
       var tagsDiv = panel.querySelector(".nf-mind-panel-tags");
-      var tags = d.tags || [];
-      if (tags.length) {
-        var tagHtml = '<p class="nf-conn-heading">Domain tags</p><div class="nf-tag-pills">';
-        tags.forEach(function(tag) {
-          var tagCfg = TAG_CONFIG[tag] || { color: "#fff", label: tag };
-          tagHtml += '<span class="nf-tag-pill" style="border-color:' + tagCfg.color + ';color:' + tagCfg.color + '">' +
-            '<span class="nf-tag-dot-sm" style="background:' + tagCfg.color + '"></span>' +
-            tagCfg.label + '</span>';
+      var cmds = d.commands || [];
+      if (cmds.length) {
+        var html = '<p class="nf-conn-heading">Commands</p><div class="nf-tag-pills">';
+        cmds.forEach(function(cmd) {
+          html += '<span class="nf-tag-pill" style="border-color:' + cfg.color + ';color:' + cfg.color + '">' + cmd + '</span>';
         });
-        tagHtml += '</div>';
-        tagsDiv.innerHTML = tagHtml;
+        html += '</div>';
+        tagsDiv.innerHTML = html;
       } else {
         tagsDiv.innerHTML = "";
       }
@@ -751,31 +570,28 @@
       links.forEach(function(l) {
         var srcId = l.source.id || l.source;
         var tgtId = l.target.id || l.target;
-        var other = null;
-        var rel = "";
-        if (srcId === d.id) { other = nodeMap[tgtId]; rel = relLabel(l.type, "out"); }
-        else if (tgtId === d.id) { other = nodeMap[srcId]; rel = relLabel(l.type, "in"); }
+        var other = null, rel = "";
+        if (srcId === d.id) { other = nodeMap[tgtId]; rel = l.type + " →"; }
+        else if (tgtId === d.id) { other = nodeMap[srcId]; rel = "← " + l.type; }
         if (other) connectedNodes.push({ node: other, rel: rel });
       });
 
       if (connectedNodes.length) {
-        var html = '<p class="nf-conn-heading">Connections (' + connectedNodes.length + ')</p><ul class="nf-conn-list">';
+        var connHtml = '<p class="nf-conn-heading">Connections (' + connectedNodes.length + ')</p><ul class="nf-conn-list">';
         connectedNodes.forEach(function(cn) {
-          html += '<li><span style="color:' + TYPE_CONFIG[cn.node.type].color + '">◆</span> ' +
+          connHtml += '<li><span style="color:' + CATEGORY_CONFIG[cn.node.category].color + '">◆</span> ' +
             '<span class="nf-conn-rel">' + cn.rel + '</span> ' +
             '<strong>' + cn.node.label + '</strong></li>';
         });
-        html += '</ul>';
-        connDiv.innerHTML = html;
+        connHtml += '</ul>';
+        connDiv.innerHTML = connHtml;
       } else {
         connDiv.innerHTML = "";
       }
 
-      /* Doc link — build relative URL from base */
-      var base = document.querySelector("base") ? document.querySelector("base").href : "/";
+      /* Doc link */
       var link = panel.querySelector(".nf-mind-panel-link");
       if (d.url) {
-        /* Determine site root by stripping /mind/ path segment */
         var currentPath = window.location.pathname;
         var siteRoot = currentPath.replace(/\/mind\/?$/, "/");
         link.href = siteRoot + d.url;
@@ -793,16 +609,6 @@
       resetHighlight();
     }
 
-    function relLabel(type, dir) {
-      if (type === "rw")   return dir === "out" ? "reads & writes" : "read & written by";
-      if (type === "r")    return dir === "out" ? "reads" : "read by";
-      if (type === "uses") return dir === "out" ? "skill informs" : "guided by skill";
-      if (type === "spawns") return dir === "out" ? "spawns" : "spawned by";
-      if (type === "orchestrates") return dir === "out" ? "orchestrates" : "orchestrated by";
-      return type;
-    }
-
-    /* Click on empty area closes panel */
     svg.on("click", function() {
       if (selectedId) closePanel();
     });
@@ -810,23 +616,23 @@
     /* ── Drag ── */
     function dragStarted(event, d) {
       if (!event.active) simulation.alphaTarget(0.3).restart();
-      if (d.type !== "core") { d.fx = d.x; d.fy = d.y; }
+      d.fx = d.x; d.fy = d.y;
     }
     function dragged(event, d) {
-      if (d.type !== "core") { d.fx = event.x; d.fy = event.y; }
+      d.fx = event.x; d.fy = event.y;
     }
     function dragEnded(event, d) {
       if (!event.active) simulation.alphaTarget(0);
-      if (d.type !== "core") { d.fx = null; d.fy = null; }
+      d.fx = null; d.fy = null;
     }
 
     /* ── Pulse animation ── */
     function animatePulse() {
       svg.selectAll(".nf-core-pulse")
         .transition().duration(2000).ease(d3.easeSinInOut)
-        .attr("r", 48).attr("opacity", 0)
+        .attr("r", 38).attr("opacity", 0)
         .transition().duration(0)
-        .attr("r", 28).attr("opacity", 0.5)
+        .attr("r", 22).attr("opacity", 0.5)
         .on("end", animatePulse);
     }
   }
@@ -846,15 +652,11 @@
     if (!document.getElementById("nf-mind-root")) return;
     if (window.d3) { initMindGraph(); return; }
 
-    /* Determine the base path of the site so the local bundle path resolves
-       correctly whether the site is served from / or a sub-path (e.g. /neuroflow/). */
     var base = document.querySelector("base");
     var basePath = base ? base.href : "/";
-    /* Strip trailing slash so we can append cleanly */
     basePath = basePath.replace(/\/$/, "");
 
     var s = document.createElement("script");
-    /* Try local bundle first; fall back to CDN if it 404s */
     s.src = basePath + "/javascripts/d3.min.js";
     s.onload = initMindGraph;
     s.onerror = function() {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,7 +93,7 @@ markdown_extensions:
   - pymdownx.smartsymbols
 
 extra:
-  version: "0.2.13"
+  version: "0.2.14"
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/stanislavjiricek/neuroflow
@@ -116,104 +116,113 @@ nav:
   - Installation: installation.md
   - Quickstart: quickstart.md
   - Mind Map: mind.md
-  - Commands:
-      - Overview: commands/index.md
+  - Personal Profile:
+      - "👤 Research Profile": commands/flowie.md
+      - "🧠 Personal Wiki": skills/wiki/SKILL.md
+      - "💡 Cross-project Ideas": commands/flowie.md
+      - "💚 Wellbeing": commands/flowie.md
+      - "📁 Project Registry": commands/flowie.md
+  - Project Memory:
+      - "🗂️ Project Memory": concepts/project-memory.md
       - "🚀 neuroflow": commands/neuroflow.md
       - "⚙️ setup": commands/setup.md
-      - Research Pipeline:
-          - "💡 ideation": commands/ideation.md
-          - "📋 preregistration": commands/preregistration.md
-          - "📝 grant-proposal": commands/grant-proposal.md
-          - "💰 finance": commands/finance.md
-          - "🧪 experiment": commands/experiment.md
-          - "🔧 tool-build": commands/tool-build.md
-          - "✅ tool-validate": commands/tool-validate.md
-          - "📁 data": commands/data.md
-          - "🔬 data-preprocess": commands/data-preprocess.md
-          - "📊 data-analyze": commands/data-analyze.md
-          - "🧠 brain-build": commands/brain-build.md
-          - "🔄 brain-optimize": commands/brain-optimize.md
-          - "▶️ brain-run": commands/brain-run.md
-          - "📝 paper": commands/paper.md
-          - "🔍 review": commands/review.md
-          - "📓 notes": commands/notes.md
-          - "📋 write-report": commands/write-report.md
-          - "🔁 pipeline": commands/pipeline.md
-          - "🎞️ slideshow": commands/slideshow.md
-          - "🖼️ poster": commands/poster.md
-          - "🧩 quiz": commands/quiz.md
-      - Utilities:
-          - "🔀 git": commands/git.md
-          - "🔁 autoresearch": commands/autoresearch.md
-          - "📤 output": commands/output.md
-          - "🔍 search": commands/search.md
-          - "👤 flowie": commands/flowie.md
-          - "🐝 hive": commands/hive.md
-          - "🎤 interview": commands/interview.md
-          - "📍 phase": commands/phase.md
-          - "🛡️ sentinel": commands/sentinel.md
-          - "💢 fails": commands/fails.md
-          - "💭 idk": commands/idk.md
+      - "📍 phase": commands/phase.md
+  - Research Pipeline:
+      - "💡 Discovery": commands/ideation.md
+      - "🔍 Search": commands/search.md
+      - "📋 Formalization": commands/preregistration.md
+      - "💰 Funding": commands/grant-proposal.md
+      - "💸 Finance": commands/finance.md
+      - "🧪 Experiment": commands/experiment.md
+      - "🔧 Tool Build": commands/tool-build.md
+      - "✅ Tool Validate": commands/tool-validate.md
+      - "📁 Data": commands/data.md
+      - "🔬 Preprocessing": commands/data-preprocess.md
+      - "📊 Analysis": commands/data-analyze.md
+      - "🧠 Brain Build": commands/brain-build.md
+      - "🔄 Brain Optimize": commands/brain-optimize.md
+      - "▶️ Brain Run": commands/brain-run.md
+      - "📝 Writing": commands/paper.md
+      - "🔍 Review": commands/review.md
+      - "📓 Notes": commands/notes.md
+      - "📋 Write Report": commands/write-report.md
+      - "🖼️ Poster": commands/poster.md
+      - "🎞️ Slideshow": commands/slideshow.md
+      - "📤 Output": commands/output.md
+      - "🧩 Quiz": commands/quiz.md
+  - Team Integration:
+      - "🐝 Hive": commands/hive.md
+  - Utilities & Quality:
+      - "🛡️ Quality & Audit": commands/sentinel.md
+      - "💢 Fails Log": commands/fails.md
+      - "⚡ Automation": commands/autoresearch.md
+      - "🔁 Pipeline": commands/pipeline.md
+      - "🔀 Git": commands/git.md
+      - "🎤 Interview": commands/interview.md
+      - "💭 Idk": commands/idk.md
   - Concepts:
       - Project Memory: concepts/project-memory.md
       - Flowie Profile: concepts/flowie.md
       - Agents: concepts/agents.md
       - Skills: concepts/skills.md
       - Hooks: concepts/hooks.md
-  - Skills:
-      - Overview: concepts/skills.md
-      - Expert:
-          - "humanizer": skills/humanizer/SKILL.md
-          - "review-neuro": skills/review-neuro/SKILL.md
-          - "worker-critic": skills/worker-critic/SKILL.md
-          - "autoresearch": skills/autoresearch/SKILL.md
-      - Phases:
-          - "phase-git": skills/phase-git/SKILL.md
-          - "phase-ideation": skills/phase-ideation/SKILL.md
-          - "phase-preregistration": skills/phase-preregistration/SKILL.md
-          - "phase-grant-proposal": skills/phase-grant-proposal/SKILL.md
-          - "phase-finance": skills/phase-finance/SKILL.md
-          - "phase-experiment": skills/phase-experiment/SKILL.md
-          - "phase-tool-build": skills/phase-tool-build/SKILL.md
-          - "phase-tool-validate": skills/phase-tool-validate/SKILL.md
-          - "phase-data": skills/phase-data/SKILL.md
-          - "phase-data-preprocess": skills/phase-data-preprocess/SKILL.md
-          - "phase-data-analyze": skills/phase-data-analyze/SKILL.md
-          - "phase-paper": skills/phase-paper/SKILL.md
-          - "phase-review": skills/phase-review/SKILL.md
-          - "phase-notes": skills/phase-notes/SKILL.md
-          - "phase-write-report": skills/phase-write-report/SKILL.md
-          - "phase-slideshow": skills/phase-slideshow/SKILL.md
-          - "phase-poster": skills/phase-poster/SKILL.md
-          - "phase-brain-build": skills/phase-brain-build/SKILL.md
-          - "phase-brain-optimize": skills/phase-brain-optimize/SKILL.md
-          - "phase-brain-run": skills/phase-brain-run/SKILL.md
-          - "phase-quiz": skills/phase-quiz/SKILL.md
-          - "phase-fails": skills/phase-fails/SKILL.md
-          - "phase-output": skills/phase-output/SKILL.md
-          - "phase-pipeline": skills/phase-pipeline/SKILL.md
-          - "phase-flowie": skills/phase-flowie/SKILL.md
-          - "phase-hive": skills/phase-hive/SKILL.md
-          - "phase-search": skills/phase-search/SKILL.md
-      - Utils:
-          - "neuroflow-core": skills/neuroflow-core/SKILL.md
-          - "neuroflow-develop": skills/neuroflow-develop/SKILL.md
-          - "notebooklm": skills/notebooklm/SKILL.md
-          - "pupil-labs-neon-realtime": skills/pupil-labs-neon-realtime/SKILL.md
-          - "setup": skills/setup/SKILL.md
-          - "skill-creator": skills/skill-creator/SKILL.md
-  - Agents:
-      - Overview: concepts/agents.md
-      - "paper-writer": agents/paper-writer.md
-      - "paper-critic": agents/paper-critic.md
-      - "poster-critic": agents/poster-critic.md
-      - "literature-review": agents/literature-review.md
-      - "scholar": agents/scholar.md
-      - "sentinel": agents/sentinel.md
-      - "sentinel-dev": agents/sentinel-dev.md
-      - "flowie": agents/flowie.md
-      - "autoresearch": agents/autoresearch.md
-  - Integrations: integrations.md
-  - Troubleshooting: troubleshooting.md
-  - Changelog: changelog.md
+  - Reference:
+      - Commands: commands/index.md
+      - Skills:
+          - Overview: concepts/skills.md
+          - Expert:
+              - "humanizer": skills/humanizer/SKILL.md
+              - "review-neuro": skills/review-neuro/SKILL.md
+              - "worker-critic": skills/worker-critic/SKILL.md
+              - "autoresearch": skills/autoresearch/SKILL.md
+          - Phases:
+              - "phase-git": skills/phase-git/SKILL.md
+              - "phase-ideation": skills/phase-ideation/SKILL.md
+              - "phase-preregistration": skills/phase-preregistration/SKILL.md
+              - "phase-grant-proposal": skills/phase-grant-proposal/SKILL.md
+              - "phase-finance": skills/phase-finance/SKILL.md
+              - "phase-experiment": skills/phase-experiment/SKILL.md
+              - "phase-tool-build": skills/phase-tool-build/SKILL.md
+              - "phase-tool-validate": skills/phase-tool-validate/SKILL.md
+              - "phase-data": skills/phase-data/SKILL.md
+              - "phase-data-preprocess": skills/phase-data-preprocess/SKILL.md
+              - "phase-data-analyze": skills/phase-data-analyze/SKILL.md
+              - "phase-paper": skills/phase-paper/SKILL.md
+              - "phase-review": skills/phase-review/SKILL.md
+              - "phase-notes": skills/phase-notes/SKILL.md
+              - "phase-write-report": skills/phase-write-report/SKILL.md
+              - "phase-slideshow": skills/phase-slideshow/SKILL.md
+              - "phase-poster": skills/phase-poster/SKILL.md
+              - "phase-brain-build": skills/phase-brain-build/SKILL.md
+              - "phase-brain-optimize": skills/phase-brain-optimize/SKILL.md
+              - "phase-brain-run": skills/phase-brain-run/SKILL.md
+              - "phase-quiz": skills/phase-quiz/SKILL.md
+              - "phase-fails": skills/phase-fails/SKILL.md
+              - "phase-output": skills/phase-output/SKILL.md
+              - "phase-pipeline": skills/phase-pipeline/SKILL.md
+              - "phase-flowie": skills/phase-flowie/SKILL.md
+              - "phase-hive": skills/phase-hive/SKILL.md
+              - "phase-search": skills/phase-search/SKILL.md
+              - "wiki": skills/wiki/SKILL.md
+          - Utils:
+              - "neuroflow-core": skills/neuroflow-core/SKILL.md
+              - "neuroflow-develop": skills/neuroflow-develop/SKILL.md
+              - "notebooklm": skills/notebooklm/SKILL.md
+              - "pupil-labs-neon-realtime": skills/pupil-labs-neon-realtime/SKILL.md
+              - "setup": skills/setup/SKILL.md
+              - "skill-creator": skills/skill-creator/SKILL.md
+      - Agents:
+          - Overview: concepts/agents.md
+          - "paper-writer": agents/paper-writer.md
+          - "paper-critic": agents/paper-critic.md
+          - "poster-critic": agents/poster-critic.md
+          - "literature-review": agents/literature-review.md
+          - "scholar": agents/scholar.md
+          - "sentinel": agents/sentinel.md
+          - "sentinel-dev": agents/sentinel-dev.md
+          - "flowie": agents/flowie.md
+          - "autoresearch": agents/autoresearch.md
+      - Integrations: integrations.md
+      - Troubleshooting: troubleshooting.md
+      - Changelog: changelog.md
 

--- a/skills/phase-flowie/SKILL.md
+++ b/skills/phase-flowie/SKILL.md
@@ -105,6 +105,35 @@ The flowie repo contains a `wellbeing/` folder for daily self-assessments. The f
 
 After every `/notes` session, the command offers to copy the formatted note to `.neuroflow/flowie/notes/` (default: yes, controlled by `sync_to_flowie` in `.neuroflow/notes/config.json`). The existing auto-sync hook pushes to GitHub. The `notes/` folder in flowie acts as a cross-project note archive.
 
+## Personal wiki
+
+The flowie repo also contains a `wiki/` folder — a Karpathy-style personal knowledge base maintained by the LLM. All wiki operations are handled by the `neuroflow:wiki` skill, which defines page formats, ingest/query/lint/add workflows, and neuroflow-specific integrations.
+
+**When to surface the wiki unprompted:**
+
+- After any `/ideation` or `/search` paper list: remind the user they can ingest papers with `/flowie --wiki-ingest`
+- After any `/notes` session: remind the user they can extract insights with `/flowie --wiki-ingest`
+- After major phase completions (`data-analyze`, `paper`): ask whether the user wants to synthesize key findings into the wiki
+- When writing a synthesis or analysis that spans multiple projects: ask whether to file it in the wiki
+
+**Wiki structure (at a glance):**
+
+```
+.neuroflow/flowie/wiki/
+├── index.md       ← catalog of all pages
+├── log.md         ← append-only operation log
+├── schema.md      ← LLM operating guide for this wiki
+├── raw/           ← immutable source documents
+└── pages/
+    ├── concepts/  ← topic pages
+    ├── entities/  ← people, tools, datasets
+    ├── sources/   ← one page per ingested source
+    ├── synthesis/ ← cross-source analysis
+    └── methods/   ← protocols, pipelines, analysis methods
+```
+
+For full wiki behavior, always load `neuroflow:wiki` when handling `--wiki-*` modes.
+
 ## Slash command
 
 When this skill is invoked directly (without `/flowie`), run the full `/flowie` workflow — show the mode menu and proceed from there. Mention `/neuroflow:flowie` at the end.
@@ -112,4 +141,5 @@ When this skill is invoked directly (without `/flowie`), run the full `/flowie` 
 ## Relevant skills
 
 - `neuroflow:neuroflow-core` — read first; defines the command lifecycle and `.neuroflow/` write rules
+- `neuroflow:wiki` — full wiki behavior for all `--wiki-*` modes
 - `neuroflow:phase-output` — flowie directory is excluded from exports by default

--- a/skills/wiki/SKILL.md
+++ b/skills/wiki/SKILL.md
@@ -1,0 +1,312 @@
+---
+name: wiki
+description: Personal knowledge base skill — Karpathy-style LLM-maintained wiki inside flowie. Handles ingest, query, lint, schema, and project-tagging workflows for .neuroflow/flowie/wiki/.
+---
+
+# wiki
+
+A personal, compounding knowledge base that lives in your flowie GitHub repo. Invoked by `/flowie --wiki-*` modes.
+
+The core insight: instead of re-deriving knowledge from raw sources on every query, the LLM incrementally builds and maintains a persistent, interlinked markdown wiki. Knowledge accumulates across sessions. Cross-references are already there. Contradictions are already flagged. The synthesis reflects everything you've read.
+
+You never write the wiki yourself — the LLM writes and maintains all of it. You curate sources and ask questions.
+
+---
+
+## Structure
+
+The wiki lives at `.neuroflow/flowie/wiki/` and is part of the flowie git repo. It syncs to GitHub like all other flowie data.
+
+```
+.neuroflow/flowie/wiki/
+├── index.md          ← catalog: every page, one-line summary, date, type (LLM maintains)
+├── log.md            ← append-only chronological log (## [date] op | title)
+├── schema.md         ← wiki conventions and LLM operating guide (auto-loaded on every operation)
+├── raw/              ← immutable source documents (human drops files here, LLM never modifies)
+│   └── assets/       ← locally downloaded images
+└── pages/
+    ├── concepts/     ← topic and idea pages
+    ├── entities/     ← people, tools, datasets, organisms, locations
+    ├── sources/      ← one summary page per ingested source
+    ├── synthesis/    ← cross-source analysis, comparisons, evolving theses
+    └── methods/      ← neuroflow-specific: protocols, pipelines, analysis methods
+```
+
+### Why `pages/methods/`?
+
+This subfolder is a neuroflow-specific addition to the Karpathy pattern. It accumulates your personal library of analysis methods, experimental protocols, and software pipelines — whether they worked or failed. Entries can be cross-referenced with `/fails` data and flowie project history.
+
+---
+
+## Wiki page format
+
+Every file in `pages/` uses this frontmatter:
+
+```yaml
+---
+title: Gamma Oscillations in Working Memory
+type: concept              # concept | entity | source | synthesis | method
+tags: [oscillations, working-memory, EEG]
+projects: [project-name]   # links to flowie project registry — ALWAYS ask
+phase: data-analyze        # most relevant neuroflow phase (optional)
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+sources: [raw/paper-xyz.md]              # raw files this page draws from
+related: [pages/concepts/theta.md]       # explicit cross-references
+status: current            # current | stale | draft
+---
+```
+
+**`projects:`** is the key neuroflow addition. Every ingest, query, and add operation MUST ask which flowie projects this relates to. Read `projects/projects.json` and suggest active/recent projects by name. The user can always answer "none" — but you must always ask.
+
+---
+
+## Page types
+
+| Type | Folder | Purpose |
+|---|---|---|
+| `source` | `pages/sources/` | One page per ingested source. Title = source title. Body = summary, key claims, quotes. |
+| `concept` | `pages/concepts/` | A topic, idea, or theme. Updated each time a relevant source is ingested. |
+| `entity` | `pages/entities/` | A person, tool, dataset, organism, or location. |
+| `synthesis` | `pages/synthesis/` | Cross-source analysis. Could be a question answer filed back as a page. |
+| `method` | `pages/methods/` | An analysis method, experimental protocol, or pipeline. Include warnings from `/fails` if applicable. |
+
+---
+
+## index.md format
+
+The index is a catalog of all pages organized by type:
+
+```markdown
+# Wiki Index
+
+Last updated: YYYY-MM-DD
+Pages: N
+
+## Sources
+| Page | Summary | Updated | Sources |
+|---|---|---|---|
+| [Title](pages/sources/slug.md) | One-line summary | YYYY-MM-DD | 1 |
+
+## Concepts
+| Page | Summary | Updated | Sources |
+|---|---|---|---|
+
+## Entities
+| Page | Summary | Updated | Sources |
+|---|---|---|---|
+
+## Synthesis
+| Page | Summary | Updated | Sources |
+|---|---|---|---|
+
+## Methods
+| Page | Summary | Updated | Sources |
+|---|---|---|---|
+```
+
+Update `index.md` after every write operation. Read `index.md` first on every query.
+
+---
+
+## log.md format
+
+Append-only. Each entry starts with a consistent prefix so it's grep-parseable:
+
+```
+## [YYYY-MM-DD] ingest | Source Title
+## [YYYY-MM-DD] query | Question summary
+## [YYYY-MM-DD] lint | N issues found
+## [YYYY-MM-DD] add | Page title
+## [YYYY-MM-DD] schema | Updated schema.md
+```
+
+Never remove or edit past entries. Always append.
+
+---
+
+## schema.md
+
+The wiki's own operating guide — defines conventions specific to this user's wiki domain. Read `schema.md` at the start of every wiki operation. If it does not exist (first run), generate a starter schema by interviewing the user about their domain and preferences.
+
+Starter schema template:
+
+```markdown
+# Wiki Schema
+
+## Domain
+{user's research domain, topics covered}
+
+## Page conventions
+- Titles: sentence case, specific (not "EEG" but "EEG in working memory tasks")
+- Summaries in index.md: max 12 words
+- Cross-references: wikilink style [[Page Title]] in body text, plus `related:` frontmatter
+
+## Ingest conventions
+- {user preferences for emphasis, what to summarize, what to skip}
+
+## Tag vocabulary
+{controlled list of tags used in this wiki}
+
+## Project tags
+{list of active flowie project names used as project: tags}
+```
+
+Evolve `schema.md` collaboratively over time. When the user says "always do X" or "don't do Y", update the schema.
+
+---
+
+## Operations
+
+### Ingest workflow (`--wiki-ingest`)
+
+1. Read `schema.md` (generate starter if missing)
+2. Read the source — either a file path the user provides, or pasted text
+3. Brief discussion: ask the user what to emphasize, any context they want captured
+4. **Read `projects/projects.json`** → list active/recent project names → ask: "Which projects does this relate to?" (MANDATORY — always ask, even if connection seems tenuous)
+5. Write `pages/sources/{slug}.md` with source summary and full frontmatter
+6. Read `index.md` → identify up to 15 existing pages that this source is relevant to → update each (add cross-reference, note new evidence, flag contradictions)
+7. For any concept/entity/method mentioned but lacking its own page: create it
+8. Update `index.md` with all new and changed pages
+9. Append to `log.md`: `## [date] ingest | {title}`
+10. Git push (flowie standard pattern)
+
+**After ingest:** ask whether this might add to `flowie/ideas.md` (if synthesis spans multiple projects) or update `profile.md` methodological stances (if it supports a strong new stance).
+
+### Query workflow (`--wiki-query`)
+
+1. Read `schema.md` + `index.md`
+2. Identify relevant pages by type, tags, projects, and relevance to the question
+3. Read those pages in full
+4. Synthesize answer with citations (link to wiki pages, not raw sources)
+5. Ask: "Would you like to file this answer as a wiki page?" — if yes, write to `pages/synthesis/{slug}.md` with full frontmatter, ask for project tags
+6. Append to `log.md`: `## [date] query | {question summary}`
+7. Git push if anything was written
+
+### Lint workflow (`--wiki-lint`)
+
+Run health checks and report findings:
+
+1. **Orphan pages** — pages in `pages/` with no inbound `related:` links from any other page
+2. **Stale pages** — pages where `updated` date is > 90 days ago and `status: current` (flag, not auto-fix)
+3. **Missing concept pages** — concepts mentioned in 3+ pages but with no dedicated page in `pages/concepts/`
+4. **Missing project tags** — pages whose body text references a known project name (from `projects.json`) but lacks it in `projects:` frontmatter
+5. **Log/page mismatch** — `log.md` ingest entries for sources with no matching file in `pages/sources/`
+6. **Cross-reference gaps** — if page A references page B in `related:`, verify B lists A in its own `related:` (bidirectional)
+7. **Methods without fails check** — pages in `pages/methods/` that have no mention of the `/fails` log (suggest checking if method appears there)
+
+After reporting, ask which issues the user wants to fix now. Fix iteratively.
+
+Append to `log.md`: `## [date] lint | {N} issues found`
+
+### Add workflow (`--wiki-add`)
+
+For manually creating or updating a wiki page:
+
+1. Ask for title (or get from args)
+2. Ask for page type (concept / entity / source / synthesis / method)
+3. Read `projects/projects.json` → ask for `projects:` tags (MANDATORY)
+4. Ask for tags, related pages, sources
+5. Ask for body content (collaboratively drafted)
+6. Write page to correct subfolder with full frontmatter
+7. Update `index.md`
+8. Append to `log.md`: `## [date] add | {title}`
+9. Git push
+
+### Schema workflow (`--wiki-schema`)
+
+Show current `schema.md`. Then ask:
+- "Would you like to update any conventions?"
+- Walk through each section collaboratively
+
+After updating, show diff, confirm, write, push.
+
+---
+
+## Initialization (`--wiki-schema` on a new wiki)
+
+If `wiki/` does not exist:
+
+1. Tell the user: "Your wiki doesn't exist yet. Let me set it up."
+2. Ask 3-4 questions to generate a starter `schema.md`:
+   - "What topics will this wiki cover? (your research domain, personal interests, both?)"
+   - "What kinds of sources will you ingest? (papers, articles, books, notes, podcasts?)"
+   - "Any conventions you want from the start? (tag vocabulary, emphasis rules?)"
+3. Create the full directory structure (index.md, log.md, schema.md, raw/, pages/ with subfolders)
+4. Create `.flow` index for the wiki folder:
+   ```markdown
+   # wiki
+   | file / folder | description |
+   |---|---|
+   | index.md | catalog of all wiki pages |
+   | log.md | append-only ingestion and query log |
+   | schema.md | wiki conventions and LLM operating guide |
+   | raw/ | immutable source documents |
+   | pages/ | LLM-maintained wiki pages |
+   ```
+5. Update `.neuroflow/flowie/.flow` to add a wiki row
+6. Git push: `git -C .neuroflow/flowie add -A && git -C .neuroflow/flowie commit -m "wiki: initialize" && git -C .neuroflow/flowie push || true`
+
+---
+
+## Neuroflow-specific integrations
+
+### Project tagging (mandatory)
+Every ingest/add/query-that-writes MUST read `projects/projects.json` and ask about project links. Even if the connection is unclear. The user can always say "none." Never skip this.
+
+### ideas.md sync
+During ingest or query, if a synthesis page spans multiple projects or generates a cross-project hypothesis, ask:
+> "This looks like a cross-project insight. Add it to flowie/ideas.md?"
+If yes, append to `ideas.md` and push.
+
+### profile.md evolution
+After a lint or synthesis that strongly supports or contradicts a methodological stance from `profile.md`, ask:
+> "This seems relevant to your profile stance on X. Update profile.md?"
+If yes, follow flowie's write rules: show diff, confirm, write, push.
+
+### Fails integration
+When writing or updating `pages/methods/` pages, check `fails/science.md` (from `.neuroflow/fails/science.md`, if present). If the method appears in the fails log, add a callout:
+```markdown
+> ⚠️ **See fails log:** This method has a recorded failure entry. Review `.neuroflow/fails/science.md` before relying on it.
+```
+
+### Paper routing prompt
+After `/ideation` or `/search` outputs papers, those commands add a closing reminder to offer wiki ingest. The wiki skill handles it when the user runs `--wiki-ingest` with a paper path or DOI.
+
+### Notes routing prompt
+After `/notes` saves a session, it adds a closing reminder offering wiki ingest. The wiki skill handles it when the user runs `--wiki-ingest` with the notes file path.
+
+---
+
+## Git sync
+
+All wiki writes use flowie's standard git pattern:
+```bash
+git -C .neuroflow/flowie pull --rebase origin main || true
+# ... write files ...
+git -C .neuroflow/flowie add -A && git -C .neuroflow/flowie commit -m "wiki: {description}" && git -C .neuroflow/flowie push || true
+```
+
+Pull before every read operation. Push after every write. Fail silently on network errors.
+
+---
+
+## Privacy rules
+
+Wiki content inherits flowie's privacy rules:
+- The wiki is stored in a **private** GitHub repository
+- Never include wiki content in external outputs (papers, reports, grant proposals, posters)
+- If the project is exported via `/output`, `.neuroflow/flowie/` (including wiki) is excluded by default
+
+---
+
+## Session log
+
+Append to `.neuroflow/sessions/YYYY-MM-DD.md` after every wiki operation:
+```
+[HH:MM] /flowie --wiki-{mode}: {brief summary}
+```
+Examples:
+- `[14:30] /flowie --wiki-ingest: ingested "Gamma in WM" paper, updated 8 pages, tagged AlphaModulation`
+- `[15:00] /flowie --wiki-query: answered "what do I know about ICA?", filed as synthesis page`
+- `[15:45] /flowie --wiki-lint: found 3 orphan pages, 1 missing concept page, fixed 2`


### PR DESCRIPTION
- Add personal wiki system (/flowie --wiki-*) as a cross-project second brain inside the flowie repo; includes ingest, query, lint, add, and schema modes with mandatory project tagging
- Rewrite mind.js as a 19-node concept map (personal profile, project memory, pipeline, team, utilities) replacing the previous 100-node skill/command/agent graph
- Restructure mkdocs.yml nav by concept category to mirror the mind map
- Add wiki nudges to /notes, /data-analyze, and /paper commands
- Add sentinel Check 12 for wiki structure health