### PR TITLE
feat: collaboration model — 3-tier tasks, meetings, multi-level wiki,…

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "neuroflow",
       "source": "./",
       "description": "End-to-end research workflow plugin for neuroscience teams — from hypothesis to publication. Supports EEG, iEEG, fMRI, eye tracking, ECG, and multimodal recordings.",
-      "version": "0.2.14",
+      "version": "0.2.15",
       "author": {
         "name": "Stanislav Jiricek"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "neuroflow",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "End-to-end research workflow plugin for neuroscience teams — from hypothesis to publication. Supports EEG, iEEG, fMRI, eye tracking, ECG, and other neuroscience modalities.",
   "author": {
     "name": "Stanislav Jiricek"

--- a/.gitignore
+++ b/.gitignore
@@ -75,8 +75,8 @@ secrets.json
 # neuroflow integration credentials (local only — do not commit)
 .neuroflow/integrations.json
 
-# flowie sync repo integration settings (may contain endpoint info — keep local)
-.neuroflow/flowie/integrations.json
+# flowie personal research OS — private per-user, never shared in project repos
+.neuroflow/flowie/
 
 # MkDocs build output
 site/

--- a/.neuroflow/project_config.md
+++ b/.neuroflow/project_config.md
@@ -1,7 +1,7 @@
 # neuroflow — project config
 
 **Project:** neuroflow Claude Code plugin
-**Plugin version:** 0.2.14
+**Plugin version:** 0.2.15
 **Phase:** active development
 **Repo:** https://github.com/stanislavjiricek/neuroflow
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@
 
 ---
 
+## What's new in 0.2.15
+
+- **[`/meeting`](commands/meeting.md)** — first-class meeting command: schedule meetings from recurring templates, prepare agendas with active task context, send Google Calendar invites, and auto-create tasks from action items at project/flowie/hive level
+- **3-tier task model** ([`/flowie --tasks --level`](commands/flowie.md)) — tasks now exist at three levels: personal flowie (private), project (git-tracked, shared with collaborators), and hive (team-wide); kanban rendering mandatory on all displays
+- **`.neuroflow/flowie/` gitignored** — flowie is personal and excluded from shared project repos; each collaborator keeps their own private flowie; collaborator join flow documented in [`phase-hive`](skills/phase-hive/SKILL.md)
+
 ## What's new in 0.2.14
 
 - **Personal wiki** ([`/flowie --wiki-*`](commands/flowie.md)) — Karpathy-style LLM-maintained knowledge base inside your flowie repo; ingest sources, query your accumulated knowledge, lint for orphan/stale pages, and build a compounding synthesis; every page is tagged to flowie projects; integrates with `/notes`, `/ideation`, `/data-analyze`, and `/paper` via closing prompts
@@ -239,6 +245,7 @@ Run `/neuroflow:<command>` in any project folder. Start with `/neuroflow:neurofl
 | [`/search`](commands/search.md) | Lightweight scoped search — use `memory:` to search `.neuroflow/` or `project:` to search the codebase; uses `flow.md` as a fast index |
 | [`/flowie`](commands/flowie.md) | Personal research OS — link a private GitHub repository as identity profile + Kanban task board + project registry with phase tracking; Claude reads the profile to personalize assistance and surfaces active tasks at session start |
 | [`/hive`](commands/hive.md) | Team knowledge layer — connect your project to a shared GitHub org repo to sync team research directions, share findings explicitly, and get team-aware recommendations |
+| [`/meeting`](commands/meeting.md) | First-class meetings — schedule from recurring templates, prepare agendas with active task context, send Google Calendar invites, and auto-create tasks from action items at project/flowie/hive level |
 
 ---
 

--- a/agents/sentinel.md
+++ b/agents/sentinel.md
@@ -69,7 +69,7 @@ List all subfolders inside `.neuroflow/` (directories only, not files).
 
 Derive the set of valid phase subfolder names dynamically:
 - Read all files in the `commands/` directory of the neuroflow plugin. Extract the `name:` field from each command's frontmatter. These are the valid phase names.
-- Also allow the standard root subfolders that are not phase-specific: `sessions`, `reasoning`, `ethics`, `preregistration`, `finance`, `flowie`.
+- Also allow the standard root subfolders that are not phase-specific: `sessions`, `reasoning`, `ethics`, `preregistration`, `finance`, `flowie`, `tasks`, `wiki`, `meetings`, `hive`.
 
 Derive the set of known skill names dynamically:
 - Read all subfolders inside the `skills/` directory of the neuroflow plugin. Each subfolder name is a skill name.
@@ -133,18 +133,41 @@ Auto-fix: for the flow.md listing, offer to add the missing row. All other issue
 
 ### 12 — Wiki structure (if present)
 
-This check only runs if `.neuroflow/flowie/wiki/` exists.
+Run for each wiki level that exists:
 
-- **index.md:** check that `wiki/index.md` exists. If it exists, verify the "Last updated" date is within the past 90 days — flag if stale.
-- **log.md:** check that `wiki/log.md` exists and is non-empty.
-- **schema.md:** check that `wiki/schema.md` exists. If missing, flag — the wiki has no operating guide and `/flowie --wiki-schema` should be run to create one.
-- **raw/ and pages/:** check that both directories exist. Flag if missing.
-- **Orphan check (light):** count files in `wiki/pages/` that are not listed in `wiki/index.md`. If more than 5 are missing, flag as index drift — suggest running `/flowie --wiki-lint`.
-- **Log vs pages consistency:** read the last 10 entries in `wiki/log.md`. For any `ingest` entry, check whether a corresponding file exists in `wiki/pages/sources/`. Flag any mismatches.
+**12a — Flowie wiki** (`if .neuroflow/flowie/wiki/` exists):
+- **index.md:** exists and "Last updated" within 90 days
+- **log.md:** exists and non-empty
+- **schema.md:** exists — if missing, flag and suggest `/flowie --wiki-schema`
+- **raw/ and pages/:** both directories exist
+- **Orphan check (light):** files in `wiki/pages/` not listed in `wiki/index.md` > 5 → flag, suggest `/flowie --wiki-lint`
+- **Log vs pages:** last 10 `ingest` entries in `log.md` — check matching file in `pages/sources/`
 
-Group all wiki warnings under a single "⚠️ wiki" section in the report. These are warnings, not blocking errors.
+Group under "⚠️ wiki (flowie)".
 
-Auto-fix: none — all wiki issues require user action via `/flowie --wiki-lint` or `/flowie --wiki-schema`.
+**12b — Project wiki** (`if .neuroflow/wiki/` exists):
+- Same checks as 12a, but paths are relative to `.neuroflow/wiki/`
+- If `.neuroflow/wiki/` exists but is empty (only `.gitkeep` stubs from init): note as uninitialized — suggest running `/wiki --schema` to initialize
+- Check that `wiki/` is listed in `.neuroflow/flow.md`
+
+Group under "⚠️ wiki (project)".
+
+Auto-fix: add missing `wiki/` row to `flow.md`. All other issues require user action.
+
+### 13 — Hive structure (if present)
+
+This check only runs if `.neuroflow/hive/` exists.
+
+- **hive.md:** check that `.neuroflow/hive/hive.md` exists and is non-empty. Flag if missing.
+- **members.md:** check that `.neuroflow/hive/members.md` exists. Flag if missing — suggest running `/hive --members` to add team roster.
+- **sync.json:** check that `.neuroflow/hive/sync.json` exists and contains `hive_repo` (non-empty) and `last_pull` fields. Flag any missing.
+- **project_config.md binding:** check that `hive_repo:` is set in `project_config.md`. If `.neuroflow/hive/` exists but `hive_repo` is absent from config, flag as inconsistency.
+- **flow.md listing:** check that `hive/` is listed in `.neuroflow/flow.md`. Flag if missing.
+- **No old `directions.md`:** if `.neuroflow/hive/directions.md` exists as a local cache, flag it — directions are now merged into `hive.md` and `directions.md` is obsolete. Offer to delete it.
+
+Group all hive warnings under "⚠️ hive". These are warnings, not blocking errors.
+
+Auto-fix: add missing `hive/` row to `flow.md`. Offer to delete obsolete `directions.md`. All other issues require user action.
 
 ## Report
 

--- a/commands/flowie.md
+++ b/commands/flowie.md
@@ -5,6 +5,7 @@ phase: utility
 reads:
   - .neuroflow/project_config.md
   - .neuroflow/flow.md
+  - .neuroflow/tasks/**
   - .neuroflow/flowie/profile.md
   - .neuroflow/flowie/ideas.md
   - .neuroflow/flowie/sync.json
@@ -22,6 +23,7 @@ writes:
   - .neuroflow/flowie/ideas.md
   - .neuroflow/flowie/sync.json
   - .neuroflow/flowie/tasks/**
+  - .neuroflow/tasks/**
   - .neuroflow/flowie/projects/projects.json
   - .neuroflow/flowie/projects/*.md
   - .neuroflow/flowie/notes/
@@ -229,7 +231,9 @@ Create `.neuroflow/flowie/` and scaffold the full structure:
 
 ## Identity
 name:
+email:
 research_domain:
+hives: []          # list of hive repos this person is a member of: [{org}/{repo}, ...]
 
 ## Methodological preferences
 <!-- Tools, approaches, paradigms you prefer -->
@@ -411,7 +415,11 @@ Ask each question one at a time. Do not rush.
 5. *"Are there any methodological stances you hold firmly? (e.g. preregistration is non-negotiable, Bayesian over frequentist, open data always)"*
 6. *"List 3 to 5 beliefs you hold about your field that guide your research decisions. These can be controversial."*
 7. *"Is there anything else you want Claude to know about how you think — your research values, pet peeves, or preferences?"*
-8. *"Would you like to track your daily wellbeing — anxiety, energy, and happiness on a 1–10 scale? Claude will prompt you to fill in a rating each day when you sync flowie. [y/N]"*
+8. *"Which team Hives are you a member of? (list as {org}/{repo}, comma-separated — or press Enter to skip)"*
+
+   Store the list as `hives: [{org}/{repo}, ...]` in `profile.md`. This lets `/hive --init` offer to pre-fill the hive repo when a project is connected to one of the listed hives.
+
+9. *"Would you like to track your daily wellbeing — anxiety, energy, and happiness on a 1–10 scale? Claude will prompt you to fill in a rating each day when you sync flowie. [y/N]"*
 
    If yes: read `wellbeing/config.json`, set `collect` to `true`, write the file, then push:
    ```bash
@@ -425,7 +433,9 @@ After collecting all answers, write a structured `profile.md`:
 
 ## Identity
 name: {name}
+email: {email or omit if not given}
 research_domain: {domain}
+hives: [{org}/{repo}, ...}]   # omit if none given
 
 ## Methodological preferences
 {methods, formatted as bullet list}
@@ -681,6 +691,8 @@ git -C .neuroflow/flowie add profile.md && git -C .neuroflow/flowie commit -m "p
 
 **Trigger:** user runs `/flowie --tasks` (with or without sub-flags).
 
+**Rendering rule (mandatory):** ALWAYS render task displays as ASCII box kanban boards. NEVER use plain lists, bullet points, or prose for any task display operation — this applies to the default board view, filtered views, `--list`, and single-task lookups. The only exception is `--list`, which has its own defined flat-list format below.
+
 Pull first:
 ```bash
 git -C .neuroflow/flowie pull --rebase origin main || true
@@ -688,17 +700,35 @@ git -C .neuroflow/flowie pull --rebase origin main || true
 
 Read `tasks/config.json` for column definitions. Read all `.md` files from all column folders (excluding `.flow`).
 
+Determine the active task level: if `--level project` or `--level hive` is passed, operate at that level (see 3-tier model below). Default is `flowie` (`.neuroflow/flowie/tasks/`).
+
+### 3-tier task levels
+
+Tasks exist at three levels with identical kanban structure:
+
+| Level | Location | Git-tracked in | Visible to |
+|-------|----------|----------------|------------|
+| `flowie` (default) | `.neuroflow/flowie/tasks/` | flowie private repo | owner only |
+| `project` | `.neuroflow/tasks/` | project repo | all collaborators |
+| `hive` | `{hive-repo}/tasks/` | hive org repo | whole team |
+
+Use `--level project` for tasks that belong to the shared project (sprint work, analysis steps, paper milestones). Use `--level hive` for team-wide tasks (shared methods, joint deadlines). Use `--level flowie` (default) for personal todos.
+
+All git operations for `--level project` target the project repo directly (no `-C` flag needed). For `--level hive`, use GitHub API or `gh` CLI targeting the hive repo.
+
 ### --tasks (no sub-flag) — ASCII Kanban board
 
-Show the non-archive columns as a horizontal board. Show at most 5 tasks per column, truncated to 20 chars. Always show the done count at the bottom. Apply `--project` filter if provided.
+Show the non-archive columns as a horizontal board. Show at most 5 tasks per column, truncated to 20 chars. Always show the done count and the active level at the bottom. Apply `--project` filter if provided.
 
 ```
 ┌─ 📥 Inbox ──────────┐  ┌─ ⚡ Active ──────────┐  ┌─ 👁 Review ──────────┐
-│ spin-tests-5ht2a    │  │ fix-rt-glasses       │  │ grant-draft          │
+│ spin-tests-5ht2a    │  │ fix-rt-glasses @stan │  │ grant-draft @jana    │
 │ ethics-form         │  │ eeg-param-sweep      │  │                      │
 └─────────────────────┘  └──────────────────────┘  └──────────────────────┘
-[done: 3 tasks]
+[done: 3 tasks · level: flowie]
 ```
+
+Show `responsible:` as `@{handle}` (truncated to fit 20-char column limit, appended after title). Omit if not set.
 
 Omit empty columns unless they are `inbox` or `active`. Show `meeting` and `ready` only if they contain tasks.
 
@@ -707,11 +737,11 @@ Omit empty columns unless they are `inbox` or `active`. Show `meeting` and `read
 Flat list of all tasks across all non-archive columns, sorted by column order then by `due` date (soonest first, undated tasks last).
 
 ```
-[inbox]   spin-tests-5ht2a     AlphaModulation  due: 2026-04-15
-[inbox]   ethics-form          RT_DES           due: —
-[active]  fix-rt-glasses       RT_DES           due: 2026-04-10
-[active]  eeg-param-sweep      AlphaModulation  due: —
-[review]  grant-draft          AlphaModulation  due: 2026-04-20
+[inbox]   spin-tests-5ht2a     AlphaModulation  @—          due: 2026-04-15
+[inbox]   ethics-form          RT_DES           @—          due: —
+[active]  fix-rt-glasses       RT_DES           @stan       due: 2026-04-10
+[active]  eeg-param-sweep      AlphaModulation  @stan       due: —
+[review]  grant-draft          AlphaModulation  @jana       due: 2026-04-20
 ```
 
 ### --tasks --add
@@ -721,20 +751,29 @@ Before starting, run the wellbeing check: if `wellbeing/config.json` has `collec
 Mini interview to create a new task. Ask:
 
 1. *"Task title?"*
-2. *"Which project? (list projects from projects.json)"*
-3. *"Phase? (optional — press enter to skip)"*
-4. *"Due date? (YYYY-MM-DD, optional)"*
-5. *"Tags? (comma-separated, optional)"*
-6. *"Blocked by? (comma-separated slugs, optional)"*
+2. *"Level? [flowie / project / hive] (default: flowie)"*
+3. *"Which project? (list projects from projects.json)"*
+4. *"Responsible? (@handle or name, optional — who owns this task)"*
+5. *"Phase? (optional — press enter to skip)"*
+6. *"Due date? (YYYY-MM-DD, optional)"*
+7. *"Tags? (comma-separated, optional)"*
+8. *"Blocked by? (comma-separated slugs, optional)"*
 
 Generate slug from title: lowercase, spaces to hyphens, strip special chars, max 40 chars.
 
-Write task file to `tasks/inbox/{slug}.md`:
+Determine task root based on level:
+- `flowie` → `tasks/inbox/` (in `.neuroflow/flowie/tasks/inbox/`)
+- `project` → `.neuroflow/tasks/inbox/`
+- `hive` → `tasks/inbox/` in hive repo (via GitHub API or `gh`)
+
+Write task file to `{task-root}/{slug}.md`:
 
 ```markdown
 ---
 title: {title}
+level: {flowie|project|hive}
 project: {project}
+responsible: {@ github handle or name, optional}
 phase: {phase or omit}
 created: {YYYY-MM-DD}
 due: {due or omit}
@@ -751,13 +790,20 @@ blocked_by: [{blocked_by or empty}]
 
 Confirm:
 ```
-Task created: tasks/inbox/{slug}.md
+Task created: [{level}] tasks/inbox/{slug}.md
 ```
 
-Push:
+Push (flowie level):
 ```bash
 git -C .neuroflow/flowie add tasks/inbox/{slug}.md && git -C .neuroflow/flowie commit -m "task: add {slug}" && git -C .neuroflow/flowie push || true
 ```
+
+Push (project level — standard git in project repo):
+```bash
+git add .neuroflow/tasks/inbox/{slug}.md && git commit -m "task: add {slug}" && git push || true
+```
+
+Push (hive level): use `gh` CLI or GitHub API to push to hive repo.
 
 ### --tasks --move \<slug\> \<column\>
 

--- a/commands/hive.md
+++ b/commands/hive.md
@@ -33,10 +33,19 @@ Parse the command for a mode flag. If no flag is given, default to `--view` if `
 | Flag | Action |
 |---|---|
 | `--init` | Connect to a Hive repo for the first time |
-| `--sync` | Pull the latest state from the Hive repo |
+| `--sync` | Pull the latest state + show change digest |
 | `--view` | Display current Hive state without syncing |
-| `--share` | Explicitly share a finding, method, or paper to Hive |
+| `--members` | View and edit the team roster |
+| `--projects` | View and manage the lab project registry |
+| `--ideas` | View and append to lab-wide cross-project ideas |
+| `--tasks` | Show and manage the team Kanban board |
 | `--recommend` | Get team-aware recommendations for the current phase |
+| `--wiki` | Show team wiki overview |
+| `--wiki-ingest` | Add a source to the team wiki (replaces --share) |
+| `--wiki-query` | Query the team wiki |
+| `--wiki-lint` | Health check the team wiki |
+| `--wiki-add` | Add a page to the team wiki manually |
+| `--wiki-schema` | View/edit team wiki conventions |
 
 ---
 

--- a/commands/meeting.md
+++ b/commands/meeting.md
@@ -1,0 +1,75 @@
+---
+name: meeting
+description: First-class meeting command — schedule meetings, prepare agendas with project context, send calendar invites, take structured notes, and auto-create tasks from action items. Supports project, flowie, and hive levels.
+phase: utility
+reads:
+  - .neuroflow/project_config.md
+  - .neuroflow/flow.md
+  - .neuroflow/tasks/**
+  - .neuroflow/meetings/config.json
+  - .neuroflow/meetings/*.md
+  - .neuroflow/hive/hive.md
+  - .neuroflow/flowie/profile.md
+  - .neuroflow/flowie/meetings/config.json
+  - .neuroflow/flowie/meetings/*.md
+writes:
+  - .neuroflow/meetings/
+  - .neuroflow/meetings/config.json
+  - .neuroflow/flowie/meetings/
+  - .neuroflow/flowie/meetings/config.json
+  - .neuroflow/tasks/**
+  - .neuroflow/sessions/YYYY-MM-DD.md
+---
+
+# /meeting
+
+First-class meeting management for neuroflow. Distinct from `/notes` (which captures unstructured live input) — `/meeting` is for planned meetings with agenda, attendees, calendar integration, and action-item-to-task conversion.
+
+Read the `neuroflow:phase-meeting` skill first. Then follow the neuroflow-core lifecycle.
+
+---
+
+## Step 0 — Check for .neuroflow/
+
+If `.neuroflow/` does not exist, stop and tell the user to run `/neuroflow` first.
+
+---
+
+## Step 1 — Parse mode flag
+
+If no flag given: default to `--list` if any meeting files exist, otherwise `--new`.
+
+| Flag | Action |
+|------|--------|
+| `--new` | Schedule a new meeting |
+| `--prepare <slug>` | Prepare agenda with project context |
+| `--view <slug>` | Show meeting file with task status inline |
+| `--list` | List all meetings at current level |
+| `--invite <slug>` | (Re)send calendar invites |
+| `--close <slug>` | Finalize meeting and convert action items to tasks |
+| `--init` | Set up recurring meeting templates |
+
+Parse `--level project|flowie|hive` (default: `project`).
+
+---
+
+## Step 2 — Execute mode
+
+Follow the instructions in `neuroflow:phase-meeting` for the selected mode.
+
+---
+
+## Step 3 — Session log
+
+Append to `.neuroflow/sessions/YYYY-MM-DD.md`:
+
+```
+[HH:MM] /meeting --{mode} — {one-line summary}
+```
+
+Examples:
+```
+[09:00] /meeting --new — created Weekly Lab Meeting 2026-04-20 (hive level), sent invites to 4 attendees
+[09:30] /meeting --prepare weekly-lab-2026-04-20 — populated agenda with 3 active tasks and 2 hive directions
+[10:00] /meeting --close weekly-lab-2026-04-20 — created 3 project tasks from action items
+```

--- a/commands/neuroflow.md
+++ b/commands/neuroflow.md
@@ -155,8 +155,27 @@ Create the following structure in the current working directory:
 .neuroflow/
 ├── project_config.md
 ├── flow.md
-└── sessions/
-    └── .gitkeep
+├── sessions/
+│   └── .gitkeep
+├── tasks/
+│   ├── inbox/
+│   ├── ready/
+│   ├── active/
+│   ├── review/
+│   ├── meeting/
+│   ├── done/
+│   └── archive/
+├── wiki/
+│   ├── index.md
+│   ├── log.md
+│   ├── schema.md
+│   ├── raw/
+│   └── pages/
+│       ├── concepts/
+│       ├── entities/
+│       ├── sources/
+│       ├── synthesis/
+│       └── methods/
 └── reasoning/
     ├── flow.md
     └── general.json
@@ -184,6 +203,10 @@ auto_issue_reporting: no
 ```
 
 **`sessions/`** — create a `.gitkeep` file. Remind the user to add `sessions/` to `.gitignore`.
+
+**`tasks/`** — create each column folder (`inbox/`, `ready/`, `active/`, `review/`, `meeting/`, `done/`, `archive/`) with a `.gitkeep` file. This is the shared project-level Kanban board — git-tracked and visible to all collaborators. Update `.neuroflow/flow.md` to include a `tasks/` row.
+
+**`wiki/`** — create the scaffold for the project-level shared wiki (`index.md`, `log.md`, `schema.md` as empty placeholders, `raw/`, `pages/concepts/`, `pages/entities/`, `pages/sources/`, `pages/synthesis/`, `pages/methods/`). The wiki is initialized properly on first `/wiki` run. Update `.neuroflow/flow.md` to include a `wiki/` row.
 
 **`reasoning/`** — create the folder with:
 - `general.json` — an empty JSON array (`[]`)
@@ -447,7 +470,20 @@ Save the list as `recommended_phases` in `project_config.md` (a simple comma-sep
 
 The `.neuroflow/` folder was already created in Step 0d. Now update it with the full content from the interview.
 
-**`project_config.md`** — overwrite the placeholder with a short dense summary using what you learned. Include: project name, institution, active phase, research question (if given), modality, tools, `plugin_version` (from `plugin.json`), `auto_issue_reporting` (from the consent question in Step 2 — `yes` or `no`), `recommended_phases` (the ordered list of phases suggested in Step 2b), an `## Output paths` table mapping each relevant phase to its detected or default output path, and (if the user linked a flowie project during Step 1b) `flowie_project: {name}`. This file is read by every command and agent — keep it concise.
+**`project_config.md`** — overwrite the placeholder with a short dense summary using what you learned. Include: project name, institution, active phase, research question (if given), modality, tools, `plugin_version` (from `plugin.json`), `auto_issue_reporting` (from the consent question in Step 2 — `yes` or `no`), `recommended_phases` (the ordered list of phases suggested in Step 2b), an `## Output paths` table mapping each relevant phase to its detected or default output path, (if the user linked a flowie project during Step 1b) `flowie_project: {name}`, and a `collaborators:` list. Ask: *"Who else is working on this project? (name, email — one per line, or press Enter to skip)"* — add each person as `- name: {name}\n  email: {email}\n  handle: {github-handle or omit}`. This list is used by `/meeting` to pull attendee emails for calendar invites. This file is read by every command and agent — keep it concise.
+
+**`.neuroflow/flowie/` gitignore:** After writing all files, check whether `.neuroflow/flowie/` is already excluded in the project's `.gitignore`. If not, print:
+
+```
+⚠️  Multi-collaborator tip: .neuroflow/flowie/ is your personal research profile —
+    it should NOT be committed to a shared repo.
+
+    Add this to your project's .gitignore:
+      .neuroflow/flowie/
+
+    Each collaborator will have their own private flowie profile.
+    Shared project tasks live in .neuroflow/tasks/ (already git-tracked).
+```
 
 **`flow.md`** — update the index to reflect only the folders that actually exist (the structure is the same as what Step 0d wrote; update the `Last changed` dates).
 

--- a/commands/wiki.md
+++ b/commands/wiki.md
@@ -1,0 +1,66 @@
+---
+name: wiki
+description: Project-level shared knowledge base — Karpathy-style LLM-maintained wiki at .neuroflow/wiki/, git-tracked and shared with all project collaborators. The shared brain for experimental rationale, analysis decisions, project literature, and methods. Use /flowie --wiki-* for personal wiki, /hive --wiki-* for team wiki.
+phase: utility
+reads:
+  - .neuroflow/project_config.md
+  - .neuroflow/flow.md
+  - .neuroflow/wiki/**
+writes:
+  - .neuroflow/wiki/
+  - .neuroflow/sessions/YYYY-MM-DD.md
+---
+
+# /wiki
+
+Project-level shared knowledge base. Lives at `.neuroflow/wiki/`, git-tracked in the project repo, visible to all collaborators.
+
+**Three-level wiki overview:**
+- `/wiki` — this command — project brain (shared with collaborators)
+- `/flowie --wiki-*` — personal wiki (private, in flowie repo)
+- `/hive --wiki-*` — team wiki (lab-wide, in hive repo)
+
+Read the `neuroflow:wiki` skill first with `level: project`. Then follow the neuroflow-core lifecycle.
+
+---
+
+## Step 0 — Check for .neuroflow/
+
+If `.neuroflow/` does not exist, stop and tell the user to run `/neuroflow` first.
+
+---
+
+## Step 1 — Parse mode flag
+
+If no flag given: default to `--view` if wiki exists, `--schema` if it does not.
+
+| Flag | Action |
+|------|--------|
+| `--view` | Show wiki overview: page count, recent activity |
+| `--ingest [path]` | Ingest a source into the project wiki |
+| `--query [question]` | Ask a question answered from the project wiki |
+| `--lint` | Health check: orphans, stale pages, missing tags |
+| `--add [title]` | Create or update a wiki page |
+| `--schema` | View or update wiki conventions (also initializes wiki) |
+
+Wiki root for all operations: `.neuroflow/wiki/`
+Git pattern: standard `git` in project root (not `-C` flowie pattern).
+
+---
+
+## Step 2 — Execute mode
+
+Follow the `neuroflow:wiki` skill at `level: project`.
+
+**Project-specific context for `projects:` tagging:**
+The current project IS the context — read `project_config.md` for project name, phase, and modality. Ask if the page also relates to other projects the user is aware of.
+
+---
+
+## Step 3 — Session log
+
+Append to `.neuroflow/sessions/YYYY-MM-DD.md`:
+
+```
+[HH:MM] /wiki --{mode} [level:project] — {brief summary}
+```

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,14 @@ title: Changelog
 
 ---
 
+## 0.2.15
+
+- **[`/meeting`](commands/meeting.md)** — first-class meeting command with recurring templates, Google Calendar invites, agenda preparation from project context, and action-item-to-task conversion at project/flowie/hive level
+- **3-tier task model** — tasks at personal (flowie), project (shared), and hive (team) levels; `--level` flag on `/flowie --tasks`; mandatory ASCII kanban rendering on all displays
+- **Collaboration model** — `.neuroflow/flowie/` gitignored from project repos; `.neuroflow/tasks/` git-tracked and shared; collaborator join flow added to `phase-hive`; `collaborators:` list in `project_config.md` for meeting invite resolution
+
+---
+
 ## 0.2.14
 
 - **Personal wiki** ([`/flowie --wiki-*`](commands/flowie.md)) — Karpathy-style LLM-maintained knowledge base inside your flowie repo; ingest sources, query accumulated knowledge, lint for orphans/contradictions/stale pages; every page is tagged to flowie projects; closing prompts in `/notes`, `/ideation`, `/data-analyze`, and `/paper`

--- a/docs/commands/meeting.md
+++ b/docs/commands/meeting.md
@@ -1,0 +1,86 @@
+# /meeting
+
+First-class meeting management for neuroflow — schedule, prepare, invite, and close meetings at project, personal (flowie), or team (hive) level.
+
+Distinct from [`/notes`](notes.md), which captures unstructured live input. `/meeting` is for planned meetings with agenda, attendees, calendar integration, and action-item-to-task conversion.
+
+---
+
+## Modes
+
+| Flag | What it does |
+|------|-------------|
+| `--new` | Schedule a new meeting (from template or custom) |
+| `--prepare <slug>` | Populate agenda with active tasks and project context |
+| `--view <slug>` | Display meeting file with linked task statuses inline |
+| `--list` | List all meetings at the current level |
+| `--invite <slug>` | Send or re-send Google Calendar invites |
+| `--close <slug>` | Finalize meeting and auto-create tasks from action items |
+| `--init` | Create recurring meeting templates |
+
+---
+
+## Meeting levels
+
+Use `--level` to specify where the meeting lives:
+
+| Level | Storage | Who sees it |
+|-------|---------|-------------|
+| `project` (default) | `.neuroflow/meetings/` | All project collaborators |
+| `flowie` | `.neuroflow/flowie/meetings/` | You only |
+| `hive` | `{hive-repo}/meetings/` | Whole team |
+
+---
+
+## Recurring templates
+
+Define templates once in `config.json` — reuse on every `/meeting --new`:
+
+```json
+{
+  "recurring": [
+    {
+      "name": "Weekly Lab Meeting",
+      "slug": "weekly-lab",
+      "duration": 60,
+      "location": "Room 301",
+      "level": "hive",
+      "default_attendees": ["all-hive-members"],
+      "agenda_template": "## Updates\n\n## Papers\n\n## Action Items"
+    }
+  ]
+}
+```
+
+`default_attendees` can be:
+- An explicit email string
+- `"all-hive-members"` — resolved from `hive.md` members table
+- `"all-project-collaborators"` — resolved from `project_config.md`
+
+---
+
+## Calendar integration
+
+`--new` optionally calls the Google Calendar MCP to create an event with all attendees, returning an event link stored in the meeting file's frontmatter.
+
+---
+
+## Action items → tasks
+
+`--close` parses the `## Action Items` section and creates tasks:
+
+```markdown
+- [ ] Fix RT pipeline → @stanislav [project/active]
+- [ ] Update ethics form [project/inbox]
+```
+
+Each item becomes a task file at the specified level and column, tagged with `meeting:{slug}`.
+
+---
+
+## Related
+
+- [`neuroflow:phase-meeting`](../skills/phase-meeting/SKILL.md) — full skill with mode-by-mode implementation
+- [`/hive`](hive.md) — team Hive for shared directions and hive-level meetings
+- [`/notes`](notes.md) — unstructured live note capture (use this for talks, seminars)
+- [`/flowie --tasks`](flowie.md) — 3-tier Kanban task board

--- a/docs/javascripts/mind.js
+++ b/docs/javascripts/mind.js
@@ -106,8 +106,8 @@
     /* ── Team Integration ── */
     {
       id: "c-team",     label: "Team Integration",     category: "team",
-      desc: "Hive — shared GitHub org repo for team-level knowledge. Coordinates research directions and surfaces cross-project findings. All sharing is explicit, never automatic.",
-      commands: ["/hive"],
+      desc: "Hive — shared GitHub org repo for team-level knowledge. Coordinates research directions and surfaces cross-project findings. Meetings with calendar integration and 3-tier task model (flowie/project/hive). All sharing is explicit, never automatic.",
+      commands: ["/hive", "/meeting"],
       url: "commands/hive/"
     },
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,7 +93,7 @@ markdown_extensions:
   - pymdownx.smartsymbols
 
 extra:
-  version: "0.2.14"
+  version: "0.2.15"
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/stanislavjiricek/neuroflow
@@ -158,6 +158,7 @@ nav:
           - "🧩 Quiz": commands/quiz.md
       - Team Integration:
           - "🐝 Hive": commands/hive.md
+          - "📅 Meeting": commands/meeting.md
       - Utilities & Quality:
           - "🛡️ Quality & Audit": commands/sentinel.md
           - "💢 Fails Log": commands/fails.md
@@ -202,6 +203,7 @@ nav:
               - "phase-pipeline": skills/phase-pipeline/SKILL.md
               - "phase-flowie": skills/phase-flowie/SKILL.md
               - "phase-hive": skills/phase-hive/SKILL.md
+              - "phase-meeting": skills/phase-meeting/SKILL.md
               - "phase-search": skills/phase-search/SKILL.md
               - "wiki": skills/wiki/SKILL.md
           - Utils:

--- a/skills/phase-flowie/SKILL.md
+++ b/skills/phase-flowie/SKILL.md
@@ -13,9 +13,22 @@ The flowie profile lives in `.neuroflow/flowie/` and consists of three files:
 
 | File | Contents |
 |---|---|
-| `profile.md` | Research identity: name, domain, methodological preferences, writing style, stances, key beliefs |
+| `profile.md` | Research identity: name, email, domain, methodological preferences, writing style, stances, key beliefs |
 | `ideas.md` | Ongoing ideas and hypotheses that span multiple projects |
 | `sync.json` | GitHub repo URL, last sync timestamp, list of linked projects |
+
+`profile.md` includes `email:` and `hives:` fields under `## Identity`:
+
+```markdown
+## Identity
+name: {name}
+email: {email}
+research_domain: {domain}
+hives: [acme-neuroscience/hive-lab, another-org/hive-research]
+```
+
+- `email:` — used by `/meeting` as the organizer address for calendar invites
+- `hives:` — list of Hive repos this person is a member of (`{org}/{repo}` format). Used by `/hive --init` to suggest pre-filling the hive repo URL when connecting a new project. Lets Claude know which teams the researcher belongs to across all their projects.
 
 The profile is private by design. It lives in a private GitHub repository and is never included in project exports or any output intended for external readers.
 
@@ -58,6 +71,20 @@ When assisting in any neuroflow phase, apply the profile as follows:
 - Match the user's register and level of technical density in your responses
 - If a stated belief or stance is relevant to the current decision, surface it: *"Your profile notes that you prefer preregistration before data collection — does that apply here?"*
 - Never be sycophantic about it. Surface it once, do not repeat.
+
+## 3-tier task model
+
+Tasks in neuroflow exist at three levels with identical kanban structure:
+
+| Level | Location | Who sees it | When to use |
+|-------|----------|-------------|-------------|
+| `flowie` | `.neuroflow/flowie/tasks/` | Owner only | Personal todos, private research tasks |
+| `project` | `.neuroflow/tasks/` | All project collaborators | Sprint work, analysis steps, paper milestones |
+| `hive` | `{hive-repo}/tasks/` | Whole team | Shared deliverables, joint deadlines |
+
+When a user runs `/flowie --tasks`, default to `flowie` level. If they pass `--level project` or `--level hive`, read/write from the corresponding location. Show `[level: flowie|project|hive]` at the bottom of every board display.
+
+`.neuroflow/flowie/` is gitignored from project repos — each collaborator has their own private flowie. `.neuroflow/tasks/` is git-tracked and shared across the team.
 
 ## Write rules for .neuroflow/flowie/
 

--- a/skills/phase-hive/SKILL.md
+++ b/skills/phase-hive/SKILL.md
@@ -1,29 +1,24 @@
 ---
 name: phase-hive
-description: Team-level knowledge layer for neuroflow. Connects a researcher's personal neuroflow project to a shared GitHub organisation repo where team research directions, cross-project findings, and recommended methods are coordinated. Use when the user wants to sync their work with a team, share findings explicitly, view team directions, or get team-aware recommendations. Never automatically copies personal project data to Hive — all sharing is explicit.
+description: Team-level knowledge layer for neuroflow. Connects a researcher's personal neuroflow project to a shared GitHub organisation repo for team identity, research directions, projects registry, knowledge base, meetings, tasks, and cross-project ideas. Never automatically copies personal project data — all sharing is explicit.
 reads:
   - .neuroflow/project_config.md
   - .neuroflow/flow.md
   - .neuroflow/hive/hive.md
-  - .neuroflow/hive/directions.md
+  - .neuroflow/hive/members.md
   - .neuroflow/hive/sync.json
 writes:
   - .neuroflow/hive/
   - .neuroflow/hive/hive.md
-  - .neuroflow/hive/directions.md
+  - .neuroflow/hive/members.md
   - .neuroflow/hive/sync.json
 ---
 
 # phase-hive — Team research layer
 
-Hive is the **team-level counterpart to flowie**. Where flowie tracks an individual researcher's project workflow and session state, Hive connects to a shared GitHub organisation private repo that the whole lab or team uses to:
+Hive is the **team-level counterpart to flowie**. Where flowie is the personal research OS (private, per-researcher), Hive is the shared lab OS (visible to all team members).
 
-- Announce shared research directions
-- Share curated findings (always explicitly — never automatic)
-- Coordinate recommended analysis methods and tools
-- Broadcast relevant literature they want all team members to see
-
-**Privacy rule (enforced absolutely):** Nothing from a personal `.neuroflow/` project is ever automatically sent to Hive. Every share is an explicit, intentional action by the researcher. The Hive is a shared workspace, not a surveillance layer.
+**Privacy rule (enforced absolutely):** Nothing from a personal `.neuroflow/` project is ever automatically sent to Hive. Every share is an explicit, intentional action. The Hive is a shared workspace, not a surveillance layer.
 
 ---
 
@@ -31,90 +26,205 @@ Hive is the **team-level counterpart to flowie**. Where flowie tracks an individ
 
 ```
 {org}/{hive-repo}/
-├── hive.md              ← team identity: who we are, what we study, norms
-├── directions.md        ← active research directions (updated by PIs / team leads)
-├── sync.json            ← sync metadata: last pull per member, last push timestamps
-└── shared/
-    ├── methods/         ← recommended analysis methods and pipelines
-    ├── literature/      ← curated papers the team wants everyone to read
-    └── findings/        ← explicitly shared results and summaries
+├── hive.md          ← team identity, norms, and active research directions
+├── members.md       ← team roster: name, email, github, role
+├── ideas.md         ← cross-project team hypotheses and open questions
+├── sync.json        ← sync metadata: last pull per member, last push timestamps
+├── projects/        ← lab project registry (same structure as flowie/projects/)
+│   ├── projects.json
+│   └── {id}.md
+├── tasks/           ← team Kanban board (same structure as project tasks)
+│   ├── inbox/
+│   ├── ready/
+│   ├── active/
+│   ├── review/
+│   ├── meeting/
+│   ├── done/
+│   └── archive/
+├── meetings/        ← team meeting files (created by /meeting --level hive)
+│   └── config.json
+└── wiki/            ← team knowledge base (same structure as flowie wiki)
+    ├── index.md
+    ├── log.md
+    ├── schema.md
+    ├── raw/
+    └── pages/
+```
+
+### File formats
+
+**`hive.md`** — team identity, norms, and directions (replaces old `hive.md` + `directions.md`):
+```markdown
+# {Team name}
+
+{Team description — what the lab studies, approach, values}
+
+## Norms
+{collaboration norms, code standards, data policies}
+
+## Active research directions
+{Directions as bullet list or ## subsections — maintained by PI/leads}
+```
+
+**`members.md`** — team roster with contacts for meeting invitations:
+```markdown
+# Team Members
+
+| name | email | github | role |
+|------|-------|--------|------|
+| {name} | {email} | {handle} | {PI/researcher/student} |
+```
+
+**`ideas.md`** — lab-wide cross-project hypotheses (analogous to flowie/ideas.md but team-level):
+```markdown
+# Team Ideas
+
+Open hypotheses, cross-project questions, and speculative directions the lab is exploring.
+
+---
+```
+
+**`projects/projects.json`** — machine index of all lab projects (same schema as flowie projects):
+```json
+{ "projects": [ { "id": "...", "description": "...", "current_phase": "...", "status": "..." } ] }
 ```
 
 ---
 
 ## Local hive state (per-project)
 
-When a project has joined a Hive, the following folder exists:
-
 ```
 .neuroflow/hive/
-├── hive.md              ← local copy of team identity (pulled from org repo)
-├── directions.md        ← local copy of team research directions
-└── sync.json            ← sync metadata: hive_repo URL, last_pull, last_push, member_handle
+├── hive.md          ← local copy of team identity + directions
+├── members.md       ← local copy of team roster
+└── sync.json        ← hive_repo URL, last_pull, last_push, member_handle
 ```
 
 ---
 
 ## Command modes
 
-This skill is invoked by the `/hive` command, which supports five modes:
-
 ### `--init`
 Connect the current neuroflow project to a Hive repo for the first time.
 
-1. Ask for the GitHub org and repo name: `{org}/{hive-repo}`
+1. **Check flowie profile first:** if `.neuroflow/flowie/profile.md` exists and contains a `hives:` list, show it as a picker before asking freeform:
+   ```
+   Your flowie profile lists these hives:
+     [1] acme-neuroscience/hive-lab
+     [2] another-org/hive-research
+     [3] Enter a different repo
+   ```
+   If the user picks one, pre-fill the org/repo. Otherwise ask freeform.
+
+2. Ask for the GitHub org and repo name: `{org}/{hive-repo}`
 2. Ask for the researcher's GitHub handle (used as `member_handle` in sync.json)
-3. Clone or fetch the hive repo to read `hive.md` and `directions.md`
-4. Create `.neuroflow/hive/` with local copies of both files and an initial `sync.json`
-5. Update `.neuroflow/flow.md` to add a `hive/` row
-6. Write `hive_repo: {org}/{hive-repo}` and `hive_member: {handle}` to `project_config.md`
-7. Confirm: print the team identity from `hive.md` and the active directions from `directions.md`
+3. Check if the hive repo already exists (via `gh` CLI or GitHub API)
+
+**If joining an existing hive repo:**
+- Clone or fetch to read `hive.md`, `members.md`, and `sync.json`
+- Create `.neuroflow/hive/` with local copies + initial sync.json
+- Update `.neuroflow/flow.md` + `project_config.md`
+- Show team identity from `hive.md` and members from `members.md`
+
+**If creating a new hive repo:**
+- Scaffold full structure (all folders and files from the structure above)
+- Ask: *"Team name and description?"*
+- Ask: *"Active research directions? (one per line)"* → write to `## Active research directions` in `hive.md`
+- Ask: *"Add team members? (name, email, GitHub handle, role — one per line, Enter to skip)"* → write to `members.md`
+- Push to GitHub: `gh repo create {org}/{hive-repo} --private`
 
 ### `--sync`
-Pull the latest state from the Hive repo and update local copies.
+Pull latest state and show a digest of what changed since last pull.
 
-1. Fetch the latest `hive.md`, `directions.md`, and `sync.json` from the org repo
-2. Update `.neuroflow/hive/hive.md` and `directions.md`
-3. Update `sync.json` with `last_pull: [timestamp]`
-4. Report what changed (diff summary: new directions, updated team info)
-5. If any new directions overlap with the current project's research question or modality, highlight them as potentially relevant
+1. Record current state: `git -C (local hive cache) log --oneline` or note last_pull timestamp
+2. Fetch `hive.md`, `members.md`, `ideas.md`, and `sync.json` from hive repo
+3. Update local `.neuroflow/hive/` copies
+4. Update `sync.json` with `last_pull: [timestamp]`
+5. **Digest:** compare old and new versions and print a structured change summary:
+   ```
+   Hive sync — 2026-04-20 10:00
+   ─────────────────────────────
+   directions: 1 new (Alpha modulation → fMRI feasibility)
+   members: no changes
+   ideas: 2 new entries
+   wiki: 3 pages updated, 1 new (method: ICA pipeline)
+   tasks: 2 new in inbox, 1 moved → done
+   ─────────────────────────────
+   ```
+6. If any new directions overlap with the current project's modality or research question, highlight them: *"New team direction may be relevant: {direction}"*
 
 ### `--view`
-Display the current state of the team Hive without syncing.
+Display current local Hive state without syncing.
 
-1. Read local `.neuroflow/hive/hive.md` and `directions.md`
-2. Read `sync.json` to show when last synced
-3. Print team identity, active directions, and last sync timestamp
-4. Note: "Run `/hive --sync` to fetch the latest updates from the team."
+1. Read `.neuroflow/hive/hive.md` and `members.md`
+2. Read `sync.json` for last sync timestamp
+3. Print team identity, directions, member count, last sync
+4. Print: `"Run /hive --sync to fetch the latest updates."`
 
-### `--share`
-Explicitly share a finding, method, or curation from this project to the Hive.
+### `--members`
+View and edit the team roster.
 
-This is the **only** way anything from a personal project reaches the Hive. It is always user-initiated.
+1. Read `members.md` from hive repo (pull first)
+2. Display the members table
+3. Options: add member, remove member, update role/email
+4. Write updated `members.md`, push to hive repo
 
-1. Ask what to share:
-   - A finding (summary + file)
-   - A recommended method or pipeline (markdown description)
-   - A curated paper (citation + abstract + why it's relevant)
-2. Ask for a title and one-line description
-3. Compose the sharing entry and show it to the user for review
-4. Only after explicit confirmation: push to `shared/{category}/{slug}.md` in the Hive repo via GitHub API (or gh CLI if available)
-5. Update local `sync.json` with `last_push: [timestamp]` and a log entry
-6. Confirm: "Shared to Hive: `shared/{category}/{slug}.md`"
+### `--projects`
+View and manage the lab project registry (analogous to `/flowie --projects`).
 
-If the user has not connected to a Hive (`--init` not run), stop and prompt them to run `/hive --init` first.
+1. Pull `projects/projects.json` from hive repo
+2. Display all lab projects as ASCII phase timeline (same format as flowie projects)
+3. Sub-flags: `--projects --add` to register a new lab project (asks id, description, repos, current phase, status)
+4. Push changes to hive repo
+
+### `--ideas`
+View and append to lab-wide cross-project ideas.
+
+1. Pull `ideas.md` from hive repo
+2. Display current ideas
+3. Ask: *"Add a new idea?"* — if yes, append to `ideas.md`, push
+4. Also triggered from wiki ingest when synthesis spans multiple projects
+
+### `--tasks`
+Read and manage the team Kanban board at `{hive-repo}/tasks/`. Same ASCII box rendering rules as `/flowie --tasks --level hive`. Tasks get `level: hive` and `responsible: @name` in frontmatter. Pull first, push after writes. Supports `--tasks`, `--tasks --list`, `--tasks --add`, `--tasks --move`, `--tasks --done`.
 
 ### `--recommend`
 Get team-aware recommendations for the current project phase.
 
-1. Read local `hive.md` and `directions.md`
-2. Read the current project's `project_config.md` to know phase, modality, and research question
-3. Check `shared/methods/` and `shared/literature/` in the Hive (if accessible) for relevant shared content
+1. Read local `hive.md` (directions section) and `members.md`
+2. Read current project's `project_config.md`
+3. Check `wiki/` for relevant methods and synthesis pages (search index.md)
 4. Surface:
-   - Team directions that overlap with this project
-   - Recommended methods shared by teammates for the same modality
-   - Literature curated by the team relevant to the research question
-5. Present as a compact digest: "Your team has shared X relevant items for your current phase"
+   - Team directions overlapping this project's modality or research question
+   - Methods from hive wiki relevant to the current phase
+   - Ideas from `ideas.md` that connect to this project
+5. Present as compact digest: *"Your team has N relevant items for your current phase"*
+
+### `--wiki`, `--wiki-ingest`, `--wiki-query`, `--wiki-lint`, `--wiki-add`, `--wiki-schema`
+Operate on the hive-level team wiki at `{hive-repo}/wiki/`. Load `neuroflow:wiki` skill with `level: hive`. Same modes as `/flowie --wiki-*` but all git operations target the hive repo. This replaces the old `shared/` folder — use `--wiki-ingest` to contribute findings, methods, and literature to the team knowledge base.
+
+---
+
+## Collaborator join flow
+
+When a new team member joins a project that already has neuroflow set up, they follow this sequence:
+
+1. **Clone the project repo** — `.neuroflow/` is present (tasks/, hive/, notes/, project_config.md are all git-tracked)
+2. **Run `/neuroflow`** — detects existing `.neuroflow/project_config.md`, shows current state, prompts for their own name and flowie setup
+3. **Check `.neuroflow/flowie/`** — if it exists from a previous collaborator's work, `git check-ignore -v .neuroflow/flowie/` should show it's gitignored; if not, add `.neuroflow/flowie/` to `.gitignore` before running `/flowie`
+4. **Run `/flowie`** — set up or link their own private flowie profile (each collaborator has a separate private `flowie` repo)
+5. **Run `/hive --sync`** — pull team directions, member list, and shared content from the hive repo
+
+**What is shared vs. private:**
+
+| Path | Shared in project repo? |
+|------|------------------------|
+| `.neuroflow/project_config.md` | Yes — shared context for all |
+| `.neuroflow/tasks/` | Yes — shared project Kanban |
+| `.neuroflow/notes/` | Yes — shared meeting notes |
+| `.neuroflow/hive/` | Yes — local cache of team data |
+| `.neuroflow/sessions/` | No — gitignored (personal logs) |
+| `.neuroflow/flowie/` | No — gitignored (personal profile) |
 
 ---
 

--- a/skills/phase-meeting/SKILL.md
+++ b/skills/phase-meeting/SKILL.md
@@ -1,0 +1,304 @@
+---
+name: phase-meeting
+description: Phase guidance for the /meeting command. Covers meeting file structure, recurring templates, attendee resolution from profiles, Google Calendar MCP integration, agenda preparation with project context, and action-item-to-task conversion at all three levels (project, flowie, hive).
+reads:
+  - .neuroflow/project_config.md
+  - .neuroflow/tasks/**
+  - .neuroflow/meetings/config.json
+  - .neuroflow/meetings/*.md
+  - .neuroflow/hive/hive.md
+  - .neuroflow/flowie/profile.md
+  - .neuroflow/flowie/meetings/config.json
+writes:
+  - .neuroflow/meetings/
+  - .neuroflow/flowie/meetings/
+  - .neuroflow/tasks/**
+---
+
+# phase-meeting
+
+The `/meeting` command manages structured meetings — distinct from `/notes` which captures unstructured live input. Meetings have schema (attendees, agenda, decisions, action items), optional calendar integration, and task creation from action items.
+
+---
+
+## Meeting levels
+
+| Level | Storage | Git-tracked in | Who sees it |
+|-------|---------|----------------|-------------|
+| `project` (default) | `.neuroflow/meetings/YYYY-MM-DD-{slug}.md` | Project repo | All collaborators |
+| `flowie` | `.neuroflow/flowie/meetings/YYYY-MM-DD-{slug}.md` | Flowie repo | Owner only |
+| `hive` | `{hive-repo}/meetings/YYYY-MM-DD-{slug}.md` | Hive org repo | Whole team |
+
+---
+
+## Meeting file format
+
+```markdown
+---
+title: {title}
+date: {YYYY-MM-DDTHH:MM:00}
+duration: {minutes}
+location: {Zoom link / room / online}
+attendees:
+  - name: {name}
+    email: {email}
+level: {project|flowie|hive}
+tags: [{tag1}, {tag2}]
+linked_tasks: []
+calendar_event_id: ""
+template: {slug of recurring template, or omit}
+---
+
+## Agenda
+
+## Notes
+
+## Decisions
+
+## Action Items
+```
+
+---
+
+## Recurring meeting templates
+
+Templates live in:
+- `.neuroflow/meetings/config.json` — project-level (shared with collaborators)
+- `.neuroflow/flowie/meetings/config.json` — personal (flowie level)
+- `{hive-repo}/meetings/config.json` — team-level (hive, synced with `--sync`)
+
+```json
+{
+  "recurring": [
+    {
+      "name": "Weekly Lab Meeting",
+      "slug": "weekly-lab",
+      "duration": 60,
+      "location": "Room 301",
+      "level": "hive",
+      "default_attendees": ["all-hive-members"],
+      "default_tags": ["lab-meeting"],
+      "agenda_template": "## Updates\n\n## Papers\n\n## Action Items"
+    },
+    {
+      "name": "Supervisor 1:1",
+      "slug": "supervisor-1on1",
+      "duration": 30,
+      "location": "Zoom",
+      "level": "flowie",
+      "default_attendees": ["supervisor@example.com"],
+      "default_tags": ["1on1"],
+      "agenda_template": "## Progress\n\n## Blockers\n\n## Next steps"
+    }
+  ]
+}
+```
+
+`default_attendees` can be:
+- An explicit email string
+- `"all-hive-members"` → resolved from `hive.md` members table
+- `"all-project-collaborators"` → resolved from `project_config.md` collaborators list
+
+---
+
+## Mode: --new
+
+1. **Check for templates:** read all `config.json` files at the relevant level(s). If any recurring templates exist, show a picker:
+   ```
+   Create meeting from template?
+     [1] Weekly Lab Meeting  (hive, 60 min, Room 301)
+     [2] Supervisor 1:1      (flowie, 30 min, Zoom)
+     [3] Custom meeting
+   ```
+
+2. **If template selected:** pre-fill title, duration, location, level, tags, and agenda from the template. Ask only for date and time.
+
+3. **If custom:** ask all fields:
+   - Title?
+   - Date and time? (YYYY-MM-DD HH:MM)
+   - Duration? (minutes, default 60)
+   - Location? (optional)
+   - Level? [project / flowie / hive] (default: project)
+   - Tags? (comma-separated, optional)
+
+4. **Resolve attendees:**
+   - For `default_attendees: ["all-hive-members"]` → read `hive.md` members table → extract name + email for each row
+   - For `default_attendees: ["all-project-collaborators"]` → read `collaborators:` from `project_config.md`
+   - For explicit email strings → use as-is
+   - For custom meeting: ask *"Who should attend? (names or emails, comma-separated)"* — look up emails from hive members and collaborators by name if given
+
+5. **Write meeting file** to the appropriate storage location (see levels table above). Filename: `YYYY-MM-DD-{slug}.md` where slug is derived from the title.
+
+6. **Calendar invite (optional):** ask *"Create Google Calendar event and send invites? [Y/n]"*
+
+   If yes:
+   - Use `mcp__claude_ai_Google_Calendar__create_event` with:
+     - `summary`: meeting title
+     - `start`: ISO 8601 datetime
+     - `end`: start + duration
+     - `location`: as given
+     - `attendees`: list of email strings
+     - `description`: the agenda from the meeting file
+   - Store the returned event ID in `calendar_event_id` in the meeting frontmatter
+
+7. Confirm:
+   ```
+   Meeting created: {title} — {date} {time}
+   File: {path}
+   Attendees: {N} · Calendar: {event link or "not sent"}
+   ```
+
+---
+
+## Mode: --prepare \<slug\>
+
+Prepopulate the `## Agenda` section with context from the project and team.
+
+1. Read the meeting file by slug (search across all levels)
+2. Read `.neuroflow/project_config.md` for current phase
+3. Read `.neuroflow/tasks/active/` and `.neuroflow/tasks/review/` — list active and under-review tasks
+4. If hive is connected: read `hive.md` directions for relevant team context
+5. If any tasks are tagged with the meeting slug, include them under a dedicated heading
+
+Compose an agenda draft:
+```markdown
+## Agenda
+
+### Project status
+- Phase: {current phase}
+- Active tasks: {list slugs with titles}
+- In review: {list slugs with titles}
+
+### Team context
+{relevant hive directions if any}
+
+### Items
+{blank or template sections}
+```
+
+Show the draft and ask *"Does this look right? Edit inline or confirm."*
+
+Write the updated `## Agenda` section back to the meeting file (preserve other sections).
+
+---
+
+## Mode: --view \<slug\>
+
+1. Find meeting file by slug
+2. Read all `linked_tasks` from frontmatter → for each, check current column in `.neuroflow/tasks/` (or hive tasks)
+3. Display meeting file with task statuses inline:
+
+```
+─────────────────────────────────────────
+  Weekly Lab Meeting — 2026-04-20 10:00
+  Location: Room 301 · Duration: 60 min
+  Attendees: Stan, Jana, Petr (3)
+  Calendar: https://calendar.google.com/...
+─────────────────────────────────────────
+
+## Agenda
+...
+
+## Linked tasks
+  [active]  fix-rt-glasses        RT_DES
+  [review]  grant-draft           AlphaModulation
+  [done]    eeg-param-sweep       AlphaModulation  ✓
+
+─────────────────────────────────────────
+```
+
+---
+
+## Mode: --list
+
+Show all meetings at the active level, sorted by date (newest first):
+
+```
+[project]  2026-04-20  Weekly Lab Meeting         weekly-lab-2026-04-20
+[project]  2026-04-13  Weekly Lab Meeting         weekly-lab-2026-04-13
+[flowie]   2026-04-17  Supervisor 1:1             supervisor-1on1-2026-04-17
+```
+
+If `--level` not given: show project and flowie levels together.
+
+---
+
+## Mode: --invite \<slug\>
+
+Re-send or send calendar invites for a meeting that doesn't have a `calendar_event_id` yet.
+
+1. Read meeting file
+2. If `calendar_event_id` is already set: ask *"Invites were already sent (event ID: {id}). Re-send? [y/N]"*
+3. Call `mcp__claude_ai_Google_Calendar__create_event` (or `update_event` if re-sending) with attendees from the meeting file
+4. Update `calendar_event_id` in frontmatter
+
+---
+
+## Mode: --close \<slug\>
+
+Finalize the meeting and convert action items to tasks.
+
+1. Read meeting file
+2. Parse `## Action Items` section — find all checkboxes:
+   ```
+   - [ ] Description → @person [level/column]
+   ```
+   - `→ @person` is optional — used to assign the task's `project` tag
+   - `[level/column]` is optional — defaults to `[project/inbox]`
+   - Unformatted items default to `[project/inbox]`
+
+3. For each unchecked item: create a task file at the specified level and column. Task frontmatter:
+   ```yaml
+   ---
+   title: {item description}
+   level: {project|flowie|hive}
+   project: {project from config, or from @person annotation}
+   created: {today}
+   tags: [meeting:{meeting-slug}]
+   ---
+   ```
+
+4. Update `linked_tasks` in the meeting frontmatter with the new task slugs.
+
+5. Report:
+   ```
+   Meeting closed: {title}
+   Tasks created: {N}
+     [project/inbox]  fix-rt-pipeline
+     [project/inbox]  update-ethics-form
+     [flowie/inbox]   review-grant-draft
+   ```
+
+6. Push all changes (meeting file + task files).
+
+---
+
+## Mode: --init
+
+Set up recurring meeting templates for the current level.
+
+1. Ask for level: [project / flowie / hive]
+2. Walk through template creation:
+   - Name? (e.g. "Weekly Lab Meeting")
+   - Slug? (auto-suggested from name, editable)
+   - Duration (minutes)?
+   - Location?
+   - Default attendees? (emails, "all-hive-members", "all-project-collaborators")
+   - Default tags?
+   - Agenda template? (section headings, freeform)
+3. Write to `config.json` at the appropriate location
+4. Confirm: `Template saved: {slug}`
+5. Ask *"Add another template? [y/N]"*
+
+---
+
+## Attendee resolution rules
+
+When resolving attendees for any mode:
+
+1. `"all-hive-members"` → read `.neuroflow/hive/hive.md` `## Members` table → return all rows as `{name, email}`
+2. `"all-project-collaborators"` → read `.neuroflow/project_config.md` `collaborators:` list → return all entries
+3. Plain email string → use as-is, name = email prefix
+4. Name string (no `@`) → search hive members and collaborators by name → use matched email; if ambiguous, ask
+
+If Google Calendar MCP is not authenticated: skip the calendar step and note *"Google Calendar not configured — run `/setup` to connect."*

--- a/skills/wiki/SKILL.md
+++ b/skills/wiki/SKILL.md
@@ -1,24 +1,40 @@
 ---
 name: wiki
-description: Personal knowledge base skill — Karpathy-style LLM-maintained wiki inside flowie. Handles ingest, query, lint, schema, and project-tagging workflows for .neuroflow/flowie/wiki/.
+description: Knowledge base skill — Karpathy-style LLM-maintained wiki at three levels (personal/flowie, project, team/hive). Handles ingest, query, lint, schema, and project-tagging workflows. Invoked by /flowie --wiki-* (personal), /wiki (project), /hive --wiki-* (team).
 ---
 
 # wiki
 
-A personal, compounding knowledge base that lives in your flowie GitHub repo. Invoked by `/flowie --wiki-*` modes.
-
-The core insight: instead of re-deriving knowledge from raw sources on every query, the LLM incrementally builds and maintains a persistent, interlinked markdown wiki. Knowledge accumulates across sessions. Cross-references are already there. Contradictions are already flagged. The synthesis reflects everything you've read.
+A compounding knowledge base maintained by the LLM. Knowledge accumulates across sessions — cross-references are already there, contradictions already flagged, synthesis reflects everything ingested.
 
 You never write the wiki yourself — the LLM writes and maintains all of it. You curate sources and ask questions.
+
+**Three levels, one skill:**
+
+| Level | Root path | Git repo | Who sees it |
+|-------|-----------|----------|-------------|
+| `flowie` | `.neuroflow/flowie/wiki/` | flowie private repo | owner only |
+| `project` | `.neuroflow/wiki/` | project repo (shared) | all collaborators |
+| `hive` | `{hive-repo}/wiki/` | hive org repo | whole team |
+
+The wiki at each level serves a different purpose:
+- **flowie** — personal knowledge, reading notes, method library, ideas across all projects
+- **project** — shared project brain: experimental rationale, analysis decisions, literature relevant to the project, methods the team uses on this project
+- **hive** — team knowledge: lab-wide methods, shared literature, cross-project synthesis, team epistemics
+
+Git operations by level:
+- `flowie`: `git -C .neuroflow/flowie ...`
+- `project`: standard `git` in project root
+- `hive`: `gh` CLI or GitHub API targeting hive org repo
 
 ---
 
 ## Structure
 
-The wiki lives at `.neuroflow/flowie/wiki/` and is part of the flowie git repo. It syncs to GitHub like all other flowie data.
+The wiki structure is identical at all three levels. The root path is resolved from the active level.
 
 ```
-.neuroflow/flowie/wiki/
+{wiki-root}/
 ├── index.md          ← catalog: every page, one-line summary, date, type (LLM maintains)
 ├── log.md            ← append-only chronological log (## [date] op | title)
 ├── schema.md         ← wiki conventions and LLM operating guide (auto-loaded on every operation)
@@ -29,7 +45,7 @@ The wiki lives at `.neuroflow/flowie/wiki/` and is part of the flowie git repo. 
     ├── entities/     ← people, tools, datasets, organisms, locations
     ├── sources/      ← one summary page per ingested source
     ├── synthesis/    ← cross-source analysis, comparisons, evolving theses
-    └── methods/      ← neuroflow-specific: protocols, pipelines, analysis methods
+    └── methods/      ← protocols, pipelines, analysis methods
 ```
 
 ### Why `pages/methods/`?
@@ -57,7 +73,12 @@ status: current            # current | stale | draft
 ---
 ```
 
-**`projects:`** is the key neuroflow addition. Every ingest, query, and add operation MUST ask which flowie projects this relates to. Read `projects/projects.json` and suggest active/recent projects by name. The user can always answer "none" — but you must always ask.
+**`projects:`** is the key neuroflow addition. Every ingest, query, and add operation MUST ask which projects this relates to. Project source by level:
+- `flowie` → read `.neuroflow/flowie/projects/projects.json`
+- `project` → context is the current project itself (from `project_config.md`); ask if it relates to other flowie projects
+- `hive` → read `{hive-repo}/projects/projects.json`
+
+The user can always answer "none" — but you must always ask.
 
 ---
 
@@ -255,12 +276,13 @@ If `wiki/` does not exist:
 Every ingest/add/query-that-writes MUST read `projects/projects.json` and ask about project links. Even if the connection is unclear. The user can always say "none." Never skip this.
 
 ### ideas.md sync
-During ingest or query, if a synthesis page spans multiple projects or generates a cross-project hypothesis, ask:
-> "This looks like a cross-project insight. Add it to flowie/ideas.md?"
-If yes, append to `ideas.md` and push.
+During ingest or query, if a synthesis page spans multiple projects or generates a cross-project hypothesis, ask based on level:
+- `flowie`: "Add to flowie/ideas.md?" → append to `.neuroflow/flowie/ideas.md`
+- `project`: "Add to team ideas?" → if hive connected, append to `{hive-repo}/ideas.md`; otherwise append to `.neuroflow/flowie/ideas.md` if flowie active
+- `hive`: "Add to hive ideas.md?" → append to `{hive-repo}/ideas.md`
 
 ### profile.md evolution
-After a lint or synthesis that strongly supports or contradicts a methodological stance from `profile.md`, ask:
+Only applies at `flowie` level. After a lint or synthesis that strongly supports or contradicts a methodological stance from `profile.md`, ask:
 > "This seems relevant to your profile stance on X. Update profile.md?"
 If yes, follow flowie's write rules: show diff, confirm, write, push.
 
@@ -280,23 +302,31 @@ After `/notes` saves a session, it adds a closing reminder offering wiki ingest.
 
 ## Git sync
 
-All wiki writes use flowie's standard git pattern:
+Git operations depend on level:
+
+**flowie level:**
 ```bash
 git -C .neuroflow/flowie pull --rebase origin main || true
-# ... write files ...
 git -C .neuroflow/flowie add -A && git -C .neuroflow/flowie commit -m "wiki: {description}" && git -C .neuroflow/flowie push || true
 ```
 
-Pull before every read operation. Push after every write. Fail silently on network errors.
+**project level:**
+```bash
+git pull --rebase origin main || true
+git add .neuroflow/wiki/ && git commit -m "wiki: {description}" && git push || true
+```
+
+**hive level:** use `gh` CLI or GitHub API to push to hive org repo. Pull via `gh api` or `git clone --depth 1` before reads.
+
+Pull before every read. Push after every write. Fail silently on network errors.
 
 ---
 
 ## Privacy rules
 
-Wiki content inherits flowie's privacy rules:
-- The wiki is stored in a **private** GitHub repository
-- Never include wiki content in external outputs (papers, reports, grant proposals, posters)
-- If the project is exported via `/output`, `.neuroflow/flowie/` (including wiki) is excluded by default
+- **flowie wiki**: private GitHub repo — never included in external outputs or exports
+- **project wiki**: git-tracked in project repo — shared with all collaborators; treat as project-confidential (not public)
+- **hive wiki**: stored in private org GitHub repo — team-wide access only
 
 ---
 
@@ -304,9 +334,9 @@ Wiki content inherits flowie's privacy rules:
 
 Append to `.neuroflow/sessions/YYYY-MM-DD.md` after every wiki operation:
 ```
-[HH:MM] /flowie --wiki-{mode}: {brief summary}
+[HH:MM] /wiki --{mode} [level:{level}]: {brief summary}
 ```
 Examples:
-- `[14:30] /flowie --wiki-ingest: ingested "Gamma in WM" paper, updated 8 pages, tagged AlphaModulation`
-- `[15:00] /flowie --wiki-query: answered "what do I know about ICA?", filed as synthesis page`
-- `[15:45] /flowie --wiki-lint: found 3 orphan pages, 1 missing concept page, fixed 2`
+- `[14:30] /wiki --ingest [level:project]: ingested "Gamma in WM" paper, updated 8 pages`
+- `[15:00] /flowie --wiki-query [level:flowie]: answered "what do I know about ICA?", filed as synthesis page`
+- `[15:45] /hive --wiki-lint [level:hive]: found 3 orphan pages, 1 missing concept page, fixed 2`


### PR DESCRIPTION
… hive restructure (0.2.15)

- /meeting command: schedule from templates, Google Calendar invites, action-item-to-task conversion at project/flowie/hive level
- /wiki command: project-level shared wiki; wiki skill now level-aware (flowie/project/hive)
- 3-tier task model: tasks at flowie (private), project (shared), hive (team); --level flag; responsible: field on all tasks with @handle shown on kanban
- Hive restructure: remove shared/, add wiki/ + projects/ + members.md + ideas.md; directions merged into hive.md; --sync shows change digest; new modes --members/--projects/--ideas/--wiki-*
- Flowie profile: email + hives[] fields; hives list pre-fills /hive --init picker
- .neuroflow/flowie/ gitignored from project repos; collaborators: list in project_config.md
- .neuroflow/tasks/ + wiki/ scaffolded on /neuroflow init
- Sentinel: Check 12b (project wiki), Check 13 (hive structure), valid subfolder list updated